### PR TITLE
Publish plugin on git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,13 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+after_success:
+- >
+  test $TRAVIS_PULL_REQUEST = "false" &&
+    ./gradlew buildPlugin &&
+    curl -i --header "Authorization: Bearer $TOKEN" \
+         -F xmlId=org.arend.lang \
+         -F file=@$(ls -d1 build/distributions/*) \
+         -F channel=Stable \
+         https://plugins.jetbrains.com/plugin/uploadPlugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ import org.jetbrains.grammarkit.tasks.GenerateParser
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+version = "0.1.0-19"
+
 plugins {
     idea
     kotlin("jvm") version "1.2.61"


### PR DESCRIPTION
When anybody pushes the repository, Travis CI wakes up and loads `.travis.yml` config, builds plugin & runs tests. If it was the master or dev branch then:

- plugin is rebuilt & uploaded to https://plugins.jetbrains.com, stable channel
- if there was a build with the same version, it will be discarded

There is a **$TOKEN** env variable, it must be set on travis-ci.com site. See #34 for details.

To publish a new version, `build.gradle.kts` must be changed: just increment `version` variable, like I did in this PR.