### PR TITLE
Update gradle-intellij-plugin & gradle-grammar-kit-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     idea
     kotlin("jvm") version "1.3.61"
-    id("org.jetbrains.intellij") version "0.4.14"
-    id("org.jetbrains.grammarkit") version "2019.3"
+    id("org.jetbrains.intellij") version "0.4.16"
+    id("org.jetbrains.grammarkit") version "2020.1"
 }
 
 repositories {


### PR DESCRIPTION
The latest gradle intellij plugin supports caching searchable options, so the build process should be faster.