### PR TITLE
Add PsiViewer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ intellij {
     pluginName = "Arend"
     updateSinceUntilBuild = true
     instrumentCode = false
-    setPlugins("yaml", "java")
+    setPlugins("yaml", "java", "PsiViewer:193-SNAPSHOT")
 }
 
 task<GenerateLexer>("generateArendLexer") {


### PR DESCRIPTION
Note: It's not gonna add it as a plugin dependency, but will install PsiViewer in the sandbox intellij. So we can preview Psi Elements in the sandbox without manually installing PsiViewer.

Tradeoff: once we update to a newer version of intellij, we'll need to update psiviewer as well.