### PR TITLE
Replace `Sequence::+=` with sequence builder

### DIFF
--- a/src/main/kotlin/org/arend/intention/SelfTargetingIntention.kt
+++ b/src/main/kotlin/org/arend/intention/SelfTargetingIntention.kt
@@ -40,15 +40,16 @@ abstract class SelfTargetingIntention<T : PsiElement>(
         val leaf2 = file.findElementAt(offset - 1)
         val commonParent = if (leaf1 != null && leaf2 != null) PsiTreeUtil.findCommonParent(leaf1, leaf2) else null
 
-        var elementsToCheck: Sequence<PsiElement> = emptySequence()
-        if (leaf1 != null) {
-            elementsToCheck += leaf1.ancestors.takeWhile { it != commonParent }
-        }
-        if (leaf2 != null) {
-            elementsToCheck += leaf2.ancestors.takeWhile { it != commonParent }
-        }
-        if (commonParent != null && commonParent !is PsiFile) {
-            elementsToCheck += commonParent.ancestors
+        val elementsToCheck = sequence {
+            if (leaf1 != null) {
+                yieldAll(leaf1.ancestors.takeWhile { it != commonParent })
+            }
+            if (leaf2 != null) {
+                yieldAll(leaf2.ancestors.takeWhile { it != commonParent })
+            }
+            if (commonParent != null && commonParent !is PsiFile) {
+                yieldAll(commonParent.ancestors)
+            }
         }
 
         for (element in elementsToCheck) {


### PR DESCRIPTION
Because `+=` looks extremely inefficient:

```kotlin
public operator fun <T> Sequence<T>.plus(elements: Sequence<T>): Sequence<T> {
    return sequenceOf(this, elements).flatten()
}

public fun <T> Sequence<Sequence<T>>.flatten(): Sequence<T> = flatten { it.iterator() }

private fun <T, R> Sequence<T>.flatten(iterator: (T) -> Iterator<R>): Sequence<R> {
    if (this is TransformingSequence<*, *>) {
        return (this as TransformingSequence<*, T>).flatten(iterator)
    }
    return FlatteningSequence(this, { it }, iterator)
}
```
