### PR TITLE
Move some info from plugin.xml to build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,10 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.grammarkit.tasks.GenerateLexer
 import org.jetbrains.grammarkit.tasks.GenerateParser
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.intellij.tasks.PatchPluginXmlTask
 
 val projectArend = project(":Arend")
+group = "org.arend.lang"
 version = projectArend.version
 
 plugins {
@@ -62,6 +64,13 @@ intellij {
     updateSinceUntilBuild = true
     instrumentCode = false
     setPlugins("yaml", "java")
+}
+
+tasks.withType<PatchPluginXmlTask> {
+    version(project.version)
+    pluginId(project.group)
+    changeNotes(file("src/main/html/change-notes.html").readText())
+    pluginDescription(file("src/main/html/description.html").readText())
 }
 
 task<GenerateLexer>("generateArendLexer") {

--- a/src/main/html/change-notes.html
+++ b/src/main/html/change-notes.html
@@ -1,0 +1,26 @@
+Language updates:
+<ul>
+    <li>Implemented pattern matching on idp</li>
+    <li>New keyword \noclassifying can be used to define classes without
+        classifying fields
+    </li>
+    <li>The type of a field can be overridden with a subtype in a subclass using
+        new keyword \override
+    </li>
+    <li>Variables can be eliminated in \case expressions now</li>
+    <li>Implemented constructor synonyms</li>
+    <li>It is possible now to implement fields using pattern matching</li>
+    <li>Now, fields and implementations in a class are typechecked in the order
+        they are specified
+    </li>
+</ul>
+
+Plugin updates:
+<ul>
+    <li>Fixed some problems with pattern generator and implemented case split
+        for \Sigma-types and records
+    </li>
+    <li>It is possible now to adjust the verbosity of pretty printer in error
+        messages
+    </li>
+</ul>

--- a/src/main/html/description.html
+++ b/src/main/html/description.html
@@ -1,0 +1,4 @@
+<a href="https://arend-lang.github.io/">Arend</a> is a proof assistant based on homotopy type theory.
+This plugin adds support for the Arend language.
+To learn more about this plugin, visit the <a
+        href="https://arend-lang.github.io/about/intellij-features">website</a>.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,34 +1,6 @@
 <idea-plugin>
-    <id>org.arend.lang</id>
     <name>Arend</name>
-    <version>1.2.0</version>
     <vendor>JetBrains</vendor>
-
-    <description><![CDATA[
-      <a href="https://arend-lang.github.io/">Arend</a> is a proof assistant based on homotopy type theory.
-      This plugin adds support for the Arend language.
-      To learn more about this plugin, visit the <a href="https://arend-lang.github.io/about/intellij-features">website</a>.
-    ]]></description>
-
-    <change-notes><![CDATA[
-      Language updates:
-      <ul>
-        <li>Implemented pattern matching on idp</li>
-        <li>New keyword \noclassifying can be used to define classes without classifying fields</li>
-        <li>The type of a field can be overridden with a subtype in a subclass using new keyword \override</li>
-        <li>Variables can be eliminated in \case expressions now</li>
-        <li>Implemented constructor synonyms</li>
-        <li>It is possible now to implement fields using pattern matching</li>
-        <li>Now, fields and implementations in a class are typechecked in the order they are specified</li>
-      </ul>
-
-      Plugin updates:
-      <ul>
-        <li>Fixed some problems with pattern generator and implemented case split for \Sigma-types and records</li>
-        <li>It is possible now to adjust the verbosity of pretty printer in error messages</li>
-      </ul>
-    ]]>
-    </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
     <idea-version since-build="193.5233"/>


### PR DESCRIPTION
By doing this, we have:

+ IntelliJ features in editing HTML files (before, we edit a plain text chunk in the CDATA block)
+ Once we update Arend version, we automatically get updated plugin version as well

This comes after #142