### PR TITLE
Avoid name clash in "Add missing clauses" quick fix

### DIFF
--- a/src/main/kotlin/org/arend/quickfix/ImplementMissingClausesQuickFix.kt
+++ b/src/main/kotlin/org/arend/quickfix/ImplementMissingClausesQuickFix.kt
@@ -44,6 +44,7 @@ class ImplementMissingClausesQuickFix(private val missingClausesError: MissingCl
         val psiFactory = ArendPsiFactory(project)
         val element = causeRef.element ?: return
         clauses.clear()
+        val definedVariables = collectDefinedVariables(element)
 
         missingClausesError.setMaxListSize(service<ArendSettings>().clauseActualLimit)
         for (clause in missingClausesError.limitedMissingClauses.reversed()) if (clause != null) {
@@ -71,7 +72,8 @@ class ImplementMissingClausesQuickFix(private val missingClausesError: MissingCl
                 val recursiveTypeUsagesInBindingsIterator = recursiveTypeUsagesInBindings.iterator()
                 val elimMode = missingClausesError.isElim
                 var parameter2: DependentLink? = if (!elimMode) missingClausesError.parameters else null
-                val clauseBindings = ArrayList<Variable>()
+//                val clauseBindings = ArrayList<Variable>()
+                val clauseBindings: MutableList<Variable> = definedVariables.toMutableList()
                 var i = 0
                 while (iterator.hasNext()) {
                     val pattern = iterator.next()

--- a/src/main/kotlin/org/arend/quickfix/ImplementMissingClausesQuickFix.kt
+++ b/src/main/kotlin/org/arend/quickfix/ImplementMissingClausesQuickFix.kt
@@ -44,7 +44,7 @@ class ImplementMissingClausesQuickFix(private val missingClausesError: MissingCl
         val psiFactory = ArendPsiFactory(project)
         val element = causeRef.element ?: return
         clauses.clear()
-        val definedVariables = collectDefinedVariables(element)
+        val definedVariables: List<Variable> = collectDefinedVariables(element)
 
         missingClausesError.setMaxListSize(service<ArendSettings>().clauseActualLimit)
         for (clause in missingClausesError.limitedMissingClauses.reversed()) if (clause != null) {
@@ -72,7 +72,6 @@ class ImplementMissingClausesQuickFix(private val missingClausesError: MissingCl
                 val recursiveTypeUsagesInBindingsIterator = recursiveTypeUsagesInBindings.iterator()
                 val elimMode = missingClausesError.isElim
                 var parameter2: DependentLink? = if (!elimMode) missingClausesError.parameters else null
-//                val clauseBindings = ArrayList<Variable>()
                 val clauseBindings: MutableList<Variable> = definedVariables.toMutableList()
                 var i = 0
                 while (iterator.hasNext()) {

--- a/src/main/kotlin/org/arend/refactoring/ArendRefactoringUtils.kt
+++ b/src/main/kotlin/org/arend/refactoring/ArendRefactoringUtils.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiRecursiveElementVisitor
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.codeStyle.CodeStyleManager
 import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parents
 import com.intellij.psi.util.siblings
 import org.arend.core.context.param.DependentLink
 import org.arend.core.definition.Definition
@@ -596,6 +597,15 @@ fun isInfix(prec: ArendPrec): Boolean = prec.infixLeftKw != null || prec.infixNo
 fun calculateOccupiedNames(occupiedNames: Collection<Variable>, parameterName: String?, nRecursiveBindings: Int) =
         if (nRecursiveBindings > 1 && parameterName != null && parameterName.isNotEmpty() && !Character.isDigit(parameterName.last()))
             occupiedNames.plus(VariableImpl(parameterName)) else occupiedNames
+
+fun collectDefinedVariables(startElement: ArendCompositeElement): List<Variable> {
+    val definedVariables = mutableListOf<Variable>()
+    for (clause: ArendClause in startElement.parents.filterIsInstance<ArendClause>()) {
+        val identifiers: List<String> = clause.patternList.flatMap { it.atomPatternOrPrefixList }.mapNotNull { it.defIdentifier?.name }
+        definedVariables.addAll(identifiers.map(::VariableImpl))
+    }
+    return definedVariables
+}
 
 /**
  * The purpose of this function is to insert a pair of parenthesis

--- a/src/test/kotlin/org/arend/quickfix/MissingClausesQuickFixTest.kt
+++ b/src/test/kotlin/org/arend/quickfix/MissingClausesQuickFixTest.kt
@@ -503,4 +503,21 @@ class MissingClausesQuickFixTest: QuickFixTestBase() {
        \func foo (x y : Nat) (p : x = y) : Nat \elim p
          | Prelude.idp => {?} 
     """)
+
+    fun `test shadowed names from parent case`() = typedQuickFixTest("Implement", """
+        $listDefinition
+        
+        \func foo {A : \Type} (list : List A) : Nat \elim list
+          | nil => 0
+          | :: x xs => \case \elim{-caret-} xs \with {}
+    """, """
+        $listDefinition
+        
+        \func foo {A : \Type} (list : List A) : Nat \elim list
+          | nil => 0
+          | :: x xs => \case \elim xs \with {
+            | nil => {?}
+            | :: x1 xs1 => {?}
+          }
+    """)
 }

--- a/src/test/kotlin/org/arend/quickfix/MissingClausesQuickFixTest.kt
+++ b/src/test/kotlin/org/arend/quickfix/MissingClausesQuickFixTest.kt
@@ -520,4 +520,16 @@ class MissingClausesQuickFixTest: QuickFixTestBase() {
             | :: x1 xs1 => {?}
           }
     """)
+
+    fun `test avoid shadowing let binding`() = typedQuickFixTest("Implement", """
+       \data Wrapper (A : \Type) | wrapped (x : A)
+        
+       \func foo (w : Wrapper Nat) : Nat => \let x => 0 \in \case \elim{-caret-} w \with 
+    """, """
+       \data Wrapper (A : \Type) | wrapped (x : A)
+        
+       \func foo (w : Wrapper Nat) : Nat => \let x => 0 \in \case \elim w \with {
+         | wrapped x1 => {?}
+       }        
+    """)
 }


### PR DESCRIPTION
It is inconvenient to create missing clauses in nested case expressions --  name generator completely ignores existing variable names and often hides some useful identifiers. Also, the context section in "Arend Errors" toolwindow becomes messed up.

The following fixes are intended to solve this problem.