### PR TITLE
Fix formatting of multi-line doc comments

### DIFF
--- a/src/main/kotlin/org/arend/formatting/block/SimpleArendBlock.kt
+++ b/src/main/kotlin/org/arend/formatting/block/SimpleArendBlock.kt
@@ -380,6 +380,11 @@ class SimpleArendBlock(node: ASTNode, settings: CommonCodeStyleSettings?, wrap: 
 
         parseCommentPiece(1, Indent.getNoneIndent(), false)
         while (commentText.isNotEmpty()) {
+            if (commentText == "-}") {
+                parseCommentPiece(commentText.length, oneSpaceIndent, false)
+                break
+            }
+
             if (commentText[0] == '-')
                 parseCommentPiece(1, oneSpaceIndent, true)
 

--- a/src/test/kotlin/org/arend/formatting/ArendReformatTest.kt
+++ b/src/test/kotlin/org/arend/formatting/ArendReformatTest.kt
@@ -106,4 +106,5 @@ class ArendReformatTest : ArendFormatterTestBase() {
             "\\open Nat\n\n\\func test => 1\n+ 2\n+ 3",
             "\\open Nat\n\n\\func test => 1\n  + 2\n  + 3")
 
+    fun testMultilineDocCommentWithSuddenEnd() = checkReformat("{- | a\n -}", "{- | a\n -}")
 }


### PR DESCRIPTION
The formatting action breaks code if it encounters multi-line comment with `-}` as the last line.

Personally, I find this bug somewhat sad.