### PR TITLE
Add "Redundant parentheses" inspection (#237)

### DIFF
--- a/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
+++ b/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
@@ -11,11 +11,11 @@ import com.intellij.psi.PsiFile
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import com.intellij.util.castSafelyTo
-import org.arend.intention.binOp.BinOpIntentionUtil
 import org.arend.intention.unwrapParens
 import org.arend.psi.*
 import org.arend.psi.ext.ArendFunctionalBody
 import org.arend.util.ArendBundle
+import org.arend.util.isBinOp
 
 class RedundantParensInspection : LocalInspectionTool() {
     override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : ArendVisitor() {
@@ -54,12 +54,12 @@ private fun isAtomic(argumentAppExpr: ArendArgumentAppExpr): Boolean {
     return argumentAppExpr.atomFieldsAcc != null
 }
 
-fun isBinOp(atomFieldsAcc: ArendAtomFieldsAcc): Boolean {
+private fun isBinOp(atomFieldsAcc: ArendAtomFieldsAcc): Boolean {
     if (atomFieldsAcc.fieldAccList.isNotEmpty()) {
         return false
     }
     val literal = atomFieldsAcc.atom.literal ?: return false
-    return BinOpIntentionUtil.isBinOp(literal.longName) || BinOpIntentionUtil.isBinOp(literal.ipName)
+    return isBinOp(literal.longName) || isBinOp(literal.ipName)
 }
 
 private fun neverNeedsParensInParent(tuple: ArendTuple): Boolean {

--- a/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
+++ b/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
@@ -11,7 +11,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import com.intellij.util.castSafelyTo
-import org.arend.intention.unwrapParens
+import org.arend.refactoring.unwrapParens
 import org.arend.psi.*
 import org.arend.psi.ext.ArendFunctionalBody
 import org.arend.util.ArendBundle

--- a/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
+++ b/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
@@ -1,0 +1,111 @@
+package org.arend.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFixOnPsiElement
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.endOffset
+import com.intellij.refactoring.suggested.startOffset
+import com.intellij.util.castSafelyTo
+import org.arend.intention.binOp.BinOpIntentionUtil
+import org.arend.intention.unwrapParens
+import org.arend.psi.*
+import org.arend.psi.ext.ArendFunctionalBody
+import org.arend.util.ArendBundle
+
+class RedundantParensInspection : LocalInspectionTool() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : ArendVisitor() {
+        override fun visitTuple(tuple: ArendTuple) {
+            super.visitTuple(tuple)
+            val expression = unwrapParens(tuple) ?: return
+            if (neverNeedsParens(expression) || neverNeedsParensInParent(tuple)) {
+                val message = ArendBundle.message("arend.inspection.redundant.parentheses.message")
+                holder.registerProblem(tuple, message, UnwrapParensFix(tuple))
+            }
+        }
+    }
+}
+
+private fun neverNeedsParens(expression: ArendExpr): Boolean =
+        expression is ArendNewExpr &&
+                // Excludes cases like `f (\new Unit) 1`
+                expression.appPrefix == null &&
+                // Excludes cases like `f (Pair { | x => 1 }) 1`
+                expression.localCoClauseList.isEmpty() &&
+                // Excludes cases like `f (mcases \with {}) 1`
+                expression.withBody == null &&
+                expression.argumentAppExpr != null &&
+                isAtomic(expression.argumentAppExpr!!) &&
+                !isBinOp(expression.argumentAppExpr!!.atomFieldsAcc!!)
+
+private fun isAtomic(argumentAppExpr: ArendArgumentAppExpr): Boolean {
+    if (argumentAppExpr.argumentList.isNotEmpty()) {
+        return false
+    }
+    val longNameExpr = argumentAppExpr.longNameExpr
+    if (longNameExpr != null) {
+        // Excludes cases like `f (Path \levels 0 0) 1`, `f (Path \lp \lh) 1`
+        return longNameExpr.levelsExpr == null && longNameExpr.atomOnlyLevelExprList.isEmpty()
+    }
+    return argumentAppExpr.atomFieldsAcc != null
+}
+
+fun isBinOp(atomFieldsAcc: ArendAtomFieldsAcc): Boolean {
+    if (atomFieldsAcc.fieldAccList.isNotEmpty()) {
+        return false
+    }
+    val literal = atomFieldsAcc.atom.literal ?: return false
+    return BinOpIntentionUtil.isBinOp(literal.longName) || BinOpIntentionUtil.isBinOp(literal.ipName)
+}
+
+private fun neverNeedsParensInParent(tuple: ArendTuple): Boolean {
+    val parentNewExpr = tuple.parent.castSafelyTo<ArendAtom>()
+            ?.parent.castSafelyTo<ArendAtomFieldsAcc>()
+            // Excludes cases like `(f a).1`
+            ?.takeIf { it.fieldAccList.isEmpty() }
+            ?.parent.castSafelyTo<ArendArgumentAppExpr>()
+            // Excludes cases like `(f a) b`
+            ?.takeIf { it.argumentList.isEmpty() }
+            ?.parent.castSafelyTo<ArendNewExpr>()
+    // Examples of the parent new expression: (f a), \new (f a), (f a) { x => 1 }
+    val parent = parentNewExpr?.parent
+    return parent is ArendReturnExpr ||
+            // Parameter types
+            parent is ArendNameTele ||
+            parent is ArendFieldTele ||
+            parent is ArendTypedExpr ||
+            // Bodies, Clauses, CoClauses
+            parent is ArendFunctionalBody ||
+            parent is ArendDefMeta ||
+            parent is ArendClause ||
+            parent is CoClauseBase ||
+            // Clause patterns
+            parent is ArendPattern ||
+            parent is ArendAsPattern ||
+            // Expressions
+            parent is ArendPiExpr ||
+            parent is ArendLamExpr ||
+            parent is ArendLamTele ||
+            parent is ArendLetExpr ||
+            parent is ArendLetClause ||
+            parent is ArendTypeAnnotation ||
+            // Tuples
+            parent is ArendTupleExpr && (parent.colon != null || parent.parent.let { it is ArendTuple && it.tupleExprList.size > 1 || it is ArendImplicitArgument })
+}
+
+private class UnwrapParensFix(tuple: ArendTuple) : LocalQuickFixOnPsiElement(tuple) {
+    override fun getFamilyName(): String = ArendBundle.message("arend.unwrap.parentheses.fix")
+
+    override fun getText(): String = ArendBundle.message("arend.unwrap.parentheses.fix")
+
+    override fun invoke(project: Project, file: PsiFile, startElement: PsiElement, endElement: PsiElement) {
+        val tuple = startElement as ArendTuple
+        val unwrapped = unwrapParens(tuple) ?: return
+        val document = PsiDocumentManager.getInstance(project).getDocument(file) ?: return
+        document.replaceString(tuple.startOffset, tuple.endOffset, unwrapped.text)
+    }
+}

--- a/src/main/kotlin/org/arend/intention/RemoveClarifyingParensIntention.kt
+++ b/src/main/kotlin/org/arend/intention/RemoveClarifyingParensIntention.kt
@@ -11,6 +11,7 @@ import org.arend.naming.reference.GlobalReferable
 import org.arend.psi.*
 import org.arend.refactoring.rangeOfConcrete
 import org.arend.refactoring.surroundingTupleExpr
+import org.arend.refactoring.unwrapParens
 import org.arend.term.concrete.Concrete
 import org.arend.typechecking.order.PartialComparator
 import org.arend.util.ArendBundle
@@ -99,11 +100,6 @@ private fun findBinOpInParens(expression: Concrete.HoleExpression): Concrete.App
 private fun unwrapAppExprInParens(tuple: ArendTuple): ArendArgumentAppExpr? {
     val expr = unwrapParens(tuple) ?: return null
     return (expr as? ArendNewExpr)?.appExpr as? ArendArgumentAppExpr ?: return null
-}
-
-public fun unwrapParens(tuple: ArendTuple): ArendExpr? {
-    val tupleExpr = tuple.tupleExprList.singleOrNull() ?: return null
-    return if (tupleExpr.colon == null) tupleExpr.exprList.singleOrNull() else null
 }
 
 private fun doesNotNeedParens(childBinOp: Concrete.AppExpression, parentBinOp: Concrete.AppExpression): Boolean {

--- a/src/main/kotlin/org/arend/intention/RemoveClarifyingParensIntention.kt
+++ b/src/main/kotlin/org/arend/intention/RemoveClarifyingParensIntention.kt
@@ -3,7 +3,6 @@ package org.arend.intention
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import org.arend.ext.reference.Precedence
 import org.arend.intention.binOp.BinOpIntentionUtil
 import org.arend.intention.binOp.BinOpSeqProcessor
 import org.arend.intention.binOp.CaretHelper

--- a/src/main/kotlin/org/arend/intention/RemoveClarifyingParensIntention.kt
+++ b/src/main/kotlin/org/arend/intention/RemoveClarifyingParensIntention.kt
@@ -102,7 +102,7 @@ private fun unwrapAppExprInParens(tuple: ArendTuple): ArendArgumentAppExpr? {
     return (expr as? ArendNewExpr)?.appExpr as? ArendArgumentAppExpr ?: return null
 }
 
-private fun unwrapParens(tuple: ArendTuple): ArendExpr? {
+public fun unwrapParens(tuple: ArendTuple): ArendExpr? {
     val tupleExpr = tuple.tupleExprList.singleOrNull() ?: return null
     return if (tupleExpr.colon == null) tupleExpr.exprList.singleOrNull() else null
 }

--- a/src/main/kotlin/org/arend/intention/binOp/BinOpIntentionUtil.kt
+++ b/src/main/kotlin/org/arend/intention/binOp/BinOpIntentionUtil.kt
@@ -29,7 +29,7 @@ object BinOpIntentionUtil {
     internal fun isBinOpApp(expression: Concrete.AppExpression) =
             isBinOp(expression.function.data as? ArendReferenceContainer)
 
-    private fun isBinOp(binOpReference: ArendReferenceContainer?) =
+    fun isBinOp(binOpReference: ArendReferenceContainer?) =
             if (binOpReference is ArendIPName) binOpReference.infix != null
             else (resolve(binOpReference))?.precedence?.isInfix == true
 

--- a/src/main/kotlin/org/arend/intention/binOp/BinOpIntentionUtil.kt
+++ b/src/main/kotlin/org/arend/intention/binOp/BinOpIntentionUtil.kt
@@ -3,15 +3,13 @@ package org.arend.intention.binOp
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.util.castSafelyTo
-import org.arend.naming.reference.AliasReferable
-import org.arend.naming.reference.GlobalReferable
 import org.arend.psi.ArendArgumentAppExpr
 import org.arend.psi.ArendIPName
 import org.arend.psi.ArendLongName
 import org.arend.psi.ext.ArendReferenceContainer
 import org.arend.term.concrete.Concrete
 import org.arend.util.appExprToConcrete
+import org.arend.util.isBinOp
 
 object BinOpIntentionUtil {
     internal fun findBinOp(element: PsiElement): ArendReferenceContainer? {
@@ -29,14 +27,6 @@ object BinOpIntentionUtil {
     internal fun isBinOpApp(expression: Concrete.AppExpression) =
             isBinOp(expression.function.data as? ArendReferenceContainer)
 
-    fun isBinOp(binOpReference: ArendReferenceContainer?) =
-            if (binOpReference is ArendIPName) binOpReference.infix != null
-            else (resolve(binOpReference))?.precedence?.isInfix == true
-
     private fun skipWhiteSpacesBackwards(element: PsiElement) =
             if (element is PsiWhiteSpace) PsiTreeUtil.prevCodeLeaf(element) else element
-
-    private fun resolve(reference: ArendReferenceContainer?): GlobalReferable? =
-            reference?.resolve?.castSafelyTo<GlobalReferable>()
-                    ?.let { if (it.hasAlias() && it.aliasName == reference.referenceName) AliasReferable(it) else it }
 }

--- a/src/main/kotlin/org/arend/intention/binOp/BinOpIntentionUtil.kt
+++ b/src/main/kotlin/org/arend/intention/binOp/BinOpIntentionUtil.kt
@@ -3,6 +3,8 @@ package org.arend.intention.binOp
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.castSafelyTo
+import org.arend.naming.reference.AliasReferable
 import org.arend.naming.reference.GlobalReferable
 import org.arend.psi.ArendArgumentAppExpr
 import org.arend.psi.ArendIPName
@@ -29,8 +31,12 @@ object BinOpIntentionUtil {
 
     private fun isBinOp(binOpReference: ArendReferenceContainer?) =
             if (binOpReference is ArendIPName) binOpReference.infix != null
-            else (binOpReference?.resolve as? GlobalReferable)?.precedence?.isInfix == true
+            else (resolve(binOpReference))?.precedence?.isInfix == true
 
     private fun skipWhiteSpacesBackwards(element: PsiElement) =
             if (element is PsiWhiteSpace) PsiTreeUtil.prevCodeLeaf(element) else element
+
+    private fun resolve(reference: ArendReferenceContainer?): GlobalReferable? =
+            reference?.resolve?.castSafelyTo<GlobalReferable>()
+                    ?.let { if (it.hasAlias() && it.aliasName == reference.referenceName) AliasReferable(it) else it }
 }

--- a/src/main/kotlin/org/arend/refactoring/ArendRefactoringUtils.kt
+++ b/src/main/kotlin/org/arend/refactoring/ArendRefactoringUtils.kt
@@ -585,6 +585,11 @@ fun surroundingTupleExpr(baseExpr: ArendExpr): ArendTupleExpr? =
                 newExpr.parent as? ArendTupleExpr else null
         }
 
+fun unwrapParens(tuple: ArendTuple): ArendExpr? {
+    val tupleExpr = tuple.tupleExprList.singleOrNull() ?: return null
+    return if (tupleExpr.colon == null) tupleExpr.exprList.singleOrNull() else null
+}
+
 fun transformPostfixToPrefix(psiFactory: ArendPsiFactory,
                              argumentOrFieldsAcc: PsiElement,
                              defArgsData: DefAndArgsInParsedBinopResult): ArendArgumentAppExpr? {

--- a/src/main/kotlin/org/arend/util/ArendBinOpUtils.kt
+++ b/src/main/kotlin/org/arend/util/ArendBinOpUtils.kt
@@ -4,18 +4,21 @@ import com.intellij.lang.ASTNode
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.parentOfType
+import com.intellij.util.castSafelyTo
+import org.arend.naming.reference.AliasReferable
+import org.arend.naming.reference.GlobalReferable
 import org.arend.naming.reference.Referable
 import org.arend.psi.ArendExpr
 import org.arend.psi.ArendIPName
 import org.arend.psi.ArendImplicitArgument
 import org.arend.psi.ext.ArendReferenceContainer
 import org.arend.psi.ext.ArendSourceNode
+import org.arend.resolving.util.parseBinOp
+import org.arend.resolving.util.resolveReference
 import org.arend.term.Fixity
 import org.arend.term.abs.Abstract
 import org.arend.term.abs.BaseAbstractExpressionVisitor
 import org.arend.term.concrete.Concrete
-import org.arend.resolving.util.parseBinOp
-import org.arend.resolving.util.resolveReference
 
 fun appExprToConcrete(appExpr: Abstract.Expression): Concrete.Expression? = appExprToConcrete(appExpr, false)
 
@@ -192,3 +195,11 @@ fun concreteDataToSourceNode(data: Any?): ArendSourceNode? {
 }
 
 */
+
+fun isBinOp(binOpReference: ArendReferenceContainer?) =
+        if (binOpReference is ArendIPName) binOpReference.infix != null
+        else (resolve(binOpReference))?.precedence?.isInfix == true
+
+private fun resolve(reference: ArendReferenceContainer?): GlobalReferable? =
+        reference?.resolve?.castSafelyTo<GlobalReferable>()
+                ?.let { if (it.hasAlias() && it.aliasName == reference.referenceName) AliasReferable(it) else it }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -169,6 +169,11 @@
 
         <!-- Inspections -->
         <lang.inspectionSuppressor language="Arend" implementationClass="org.arend.inspection.ArendInspectionSuppressor"/>
+        <localInspection language="Arend" groupPath="Arend"
+                         bundle="messages.ArendBundle" key="arend.inspection.redundant.parentheses.name"
+                         groupBundle="messages.InspectionsBundle" groupKey="group.names.declaration.redundancy"
+                         enabledByDefault="true" level="WEAK WARNING"
+                         implementationClass="org.arend.inspection.RedundantParensInspection"/>
 
         <!-- Intention Actions -->
         <intentionAction>

--- a/src/main/resources/inspectionDescriptions/RedundantParens.html
+++ b/src/main/resources/inspectionDescriptions/RedundantParens.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+Reports redundant parentheses in terms.
+<!-- tooltip end -->
+</body>
+</html>

--- a/src/main/resources/messages/ArendBundle.properties
+++ b/src/main/resources/messages/ArendBundle.properties
@@ -35,3 +35,7 @@ arend.expression.addClarifyingParentheses=Add clarifying parentheses
 arend.expression.removeClarifyingParentheses=Remove clarifying parentheses
 arend.expression.clarifyingParens.processingFailed=Failed to process binary operator
 arend.expression.clarifyingParens.unexpectedUseOfImplicitArgs=Unexpected use of implicit arguments after explicit ones
+
+arend.inspection.redundant.parentheses.name=Redundant parentheses
+arend.inspection.redundant.parentheses.message=Redundant parentheses
+arend.unwrap.parentheses.fix=Unwrap parentheses

--- a/src/test/kotlin/org/arend/inspection/RedundantParensInspectionTest.kt
+++ b/src/test/kotlin/org/arend/inspection/RedundantParensInspectionTest.kt
@@ -1,0 +1,60 @@
+package org.arend.inspection
+
+import org.arend.quickfix.QuickFixTestBase
+import org.arend.util.ArendBundle
+import org.intellij.lang.annotations.Language
+
+class RedundantParensInspectionTest : QuickFixTestBase() {
+    override fun setUp() {
+        super.setUp()
+        myFixture.enableInspections(RedundantParensInspection::class.java)
+    }
+
+    fun testNeverNeedsParens() = doTest()
+
+    fun testNewExpression() = doTest()
+
+    fun testReturnExpression() = doTest()
+
+    fun testParameterType() = doTest()
+
+    fun testBodyAndClauseAndCoClause() = doTest()
+
+    fun testClausePattern() = doTest()
+
+    fun testArrowExpression() = doTest()
+
+    fun testSigmaExpression() = doTest()
+
+    fun testPiExpression() = doTest()
+
+    fun testLambdaExpression() = doTest()
+
+    fun testLetExpression() = doTest()
+
+    fun testTupleExpression() = doTest()
+
+    fun testMetaDefCallWithClauses() = doTest()
+
+    fun `test fix for atomic expression in function body`() = doTypedQuickFixTest("""
+      \func test => (2){-caret-}
+    """, """
+      \func test => 2
+    """)
+
+    fun `test fix for composite expression in return type`() = doTypedQuickFixTest("""
+      \func test : (0 = 0){-caret-} => idp
+    """, """
+      \func test : 0 = 0 => idp
+    """)
+
+    private fun doTest() {
+        myFixture.configureByFile(fileName)
+        myFixture.checkHighlighting()
+    }
+
+    private fun doTypedQuickFixTest(@Language("Arend") before: String, @Language("Arend") after: String) =
+            typedQuickFixTest(ArendBundle.message("arend.unwrap.parentheses.fix"), before, after)
+
+    override val dataPath = "org/arend/inspections/redundant_parens"
+}

--- a/src/test/kotlin/org/arend/intention/SwapInfixOperatorArgumentsIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/SwapInfixOperatorArgumentsIntentionTest.kt
@@ -116,4 +116,14 @@ class SwapInfixOperatorArgumentsIntentionTest : QuickFixTestBase() {
         | \infixr 5 && A B
       \func f : Nat And Int => 1 &&{-caret-} 0
     """)
+
+    fun `test class field alias`() = doTest("""
+      \class A
+        | \infixl 7 op \alias \infixl 7 ∧ : Nat -> Nat -> Nat
+      \func f (a : A) => 1 ∧{-caret-} 2
+    """, """
+      \class A
+        | \infixl 7 op \alias \infixl 7 ∧ : Nat -> Nat -> Nat
+      \func f (a : A) => 2 ∧ 1
+    """)
 }

--- a/src/test/resources/org/arend/inspections/redundant_parens/arrow_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/arrow_expression.ard
@@ -1,0 +1,4 @@
+\func test1 => (Nat -> Nat) -> Nat
+-- False negatives. But removing parens might hurt readability, especially in the second case.
+\func test2 => (0 = 1) -> Nat
+\func test3 => (\Sigma Nat Nat) -> Nat

--- a/src/test/resources/org/arend/inspections/redundant_parens/body_and_clause_and_co_clause.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/body_and_clause_and_co_clause.ard
@@ -1,0 +1,20 @@
+\open Nat (+)
+
+\class Pair (x y : Nat)
+
+\func test1 => <weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning>
+\func test2 (n : Nat) : Nat
+  | n => <weak_warning descr="Redundant parentheses">(0 + 0)</weak_warning>
+
+\meta test3 => <weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning>
+
+\instance test4 : Pair => <weak_warning descr="Redundant parentheses">(\new Pair { | x => 0 | y => 0 })</weak_warning>
+\instance test5 : Pair
+  | x => <weak_warning descr="Redundant parentheses">(0 + 0)</weak_warning>
+  | y : Nat => <weak_warning descr="Redundant parentheses">(0 + 0)</weak_warning>
+
+\record B (n : Nat)
+\record test6 \extends B
+  | n => <weak_warning descr="Redundant parentheses">(1 + 2)</weak_warning>
+
+\func test7 => \new Pair 0 { | y => <weak_warning descr="Redundant parentheses">(0 + 0)</weak_warning> }

--- a/src/test/resources/org/arend/inspections/redundant_parens/clause_pattern.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/clause_pattern.ard
@@ -1,0 +1,5 @@
+\func test1 (p : 1 = 1) : Nat
+  | p : <weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning> => 1
+
+\func test2 (p : 1 = 1) : Nat
+  | p \as p' : <weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning> => 1

--- a/src/test/resources/org/arend/inspections/redundant_parens/lambda_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/lambda_expression.ard
@@ -1,0 +1,2 @@
+\func test1 => \lam (x : Nat) => <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>
+\func test2 => \lam {a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>} (b : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) => 1

--- a/src/test/resources/org/arend/inspections/redundant_parens/let_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/let_expression.ard
@@ -1,0 +1,3 @@
+\func test1 => \let N => Nat \in <weak_warning descr="Redundant parentheses">(N -> N)</weak_warning>
+\func test2 => \let p => <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning> \in p
+\func test3 => \let p : <weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning> => idp \in p

--- a/src/test/resources/org/arend/inspections/redundant_parens/meta_def_call_with_clauses.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/meta_def_call_with_clauses.ard
@@ -1,0 +1,4 @@
+\func f2 {A : \Type} {B : \Type} (a : A) (b : B) => <warning descr="Goal">{?}</warning>
+
+\meta mcases => 1
+\func test15 => f2 (mcases <error descr="Clauses are not allowed here">\with {}</error>) 1

--- a/src/test/resources/org/arend/inspections/redundant_parens/never_needs_parens.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/never_needs_parens.ard
@@ -1,0 +1,31 @@
+\open Nat (+)
+
+\func f2 {A : \Type} {B : \Type} (a : A) (b : B) => <warning descr="Goal">{?}</warning>
+
+\func test0 : \Sigma => ()
+
+\func test1 => 1 + <weak_warning descr="Redundant parentheses">(2)</weak_warning>
+\func test2 => <weak_warning descr="Redundant parentheses">(2)</weak_warning>
+\func test3 => f2 {Nat} <weak_warning descr="Redundant parentheses">(<weak_warning descr="Redundant parentheses">(1)</weak_warning>)</weak_warning> 2
+
+\data Empty
+\func p => Path.inProp {Empty}
+\func test4 : <weak_warning descr="\level is ignored">\level</weak_warning> <weak_warning descr="Redundant parentheses">(Empty)</weak_warning> <weak_warning descr="Redundant parentheses">(p)</weak_warning> => <warning descr="Goal">{?}</warning>
+\func test5 : <weak_warning descr="\level is ignored">\level</weak_warning> Empty (Path.inProp {Empty}) => <warning descr="Goal">{?}</warning>
+
+\class Unit
+\func test6 => f2 (\new Unit) 1
+
+\class Pair (x y : Nat)
+\func test7 => f2 (Pair { | x => 1 }) 1
+
+\func test8 => f2 (\Set 0) 1
+
+\func test9 => f2 (Path \levels 0 0) 1
+\func test10 {A : \Type \lp \lh} => f2 (Path \lp \lh) 1
+
+\func test11 => f2 (\Sigma) 1
+\func test12 => f2 (\Pi (n : Nat) -> Nat) 1
+\func test13 (e : Empty) => f2 {Empty} (\case e \with {}) 1
+
+\func test14 => f2 (+) 1

--- a/src/test/resources/org/arend/inspections/redundant_parens/new_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/new_expression.ard
@@ -1,0 +1,7 @@
+\class Pair (x y : Nat)
+
+\func test1 => \new <weak_warning descr="Redundant parentheses">(Pair 1 2)</weak_warning>
+\func test2 => <weak_warning descr="Redundant parentheses">(Pair 1)</weak_warning> { | y => 2 }
+
+\func pair (n : Nat) => (n, n)
+\func test3 => (pair 0).1

--- a/src/test/resources/org/arend/inspections/redundant_parens/parameter_type.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/parameter_type.ard
@@ -1,0 +1,15 @@
+\func test1 {a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>} (b : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) => 1
+
+\record A (f : (0 = 0) -> Nat)
+\record test2 (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) \extends A {
+  | b (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) : Nat
+  \field c (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) : Nat
+  \override f (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) : Nat
+  \default f (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) : Nat => 1
+}
+
+\class test3 (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>)
+  | test4 (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) : Nat
+
+\data test5 (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>)
+  | test6 (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>)

--- a/src/test/resources/org/arend/inspections/redundant_parens/pi_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/pi_expression.ard
@@ -1,0 +1,3 @@
+\func test1 => \Pi (n : Nat) -> <weak_warning descr="Redundant parentheses">(Nat -> Nat)</weak_warning>
+\func test2 => \Pi (n : Nat) -> <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>
+\func test3 => \Pi (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) -> Nat

--- a/src/test/resources/org/arend/inspections/redundant_parens/return_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/return_expression.ard
@@ -1,0 +1,4 @@
+\data Empty
+
+\func test1 : <weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning> => idp
+\func test2 : Empty <weak_warning descr="\level is ignored">\level</weak_warning> <weak_warning descr="Redundant parentheses">(Path.inProp {Empty})</weak_warning> => <warning descr="Goal">{?}</warning>

--- a/src/test/resources/org/arend/inspections/redundant_parens/sigma_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/sigma_expression.ard
@@ -1,0 +1,2 @@
+\func test1 => \Sigma Nat (Nat -> Nat) -- Without parens this Sigma turns into Arrow
+\func test2 => \Sigma (a : <weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>) (<weak_warning descr="Redundant parentheses">(0 = 0)</weak_warning>)

--- a/src/test/resources/org/arend/inspections/redundant_parens/tuple_expression.ard
+++ b/src/test/resources/org/arend/inspections/redundant_parens/tuple_expression.ard
@@ -1,0 +1,6 @@
+\open Nat (+)
+
+\func test1 => (<weak_warning descr="Redundant parentheses">(1 + 2)</weak_warning> : Nat, <weak_warning descr="Redundant parentheses">(3 + 4)</weak_warning>)
+
+\func f {A : \Type} => 1
+\func test2 => f {<weak_warning descr="Redundant parentheses">(1 = 1)</weak_warning> : <weak_warning descr="Redundant parentheses">(\Type 0)</weak_warning>}


### PR DESCRIPTION
Demo:

<img width="1019" alt="Screen Shot 2021-08-11 at 1 04 00 PM" src="https://user-images.githubusercontent.com/5653229/129010596-e5109291-cd7d-44b2-b18b-fe5e2e9b0b85.png">

The inspection reports redundant parentheses in 2 cases:
1. `(T)` is equivalent to `T` in any context. Example: `(2)`.
2. `(T)` is located in a context that doesn't require parentheses around `T` for any `T`. Example: `func f => (T)`.

There are other cases when redundant parentheses can occur. For example, a specific term can be used without parentheses in a specific context. These cases are not handled for now.