### PR TITLE
Enable Prelude in External Libraries back

### DIFF
--- a/src/main/kotlin/org/arend/project/ArendPreludeLibraryRootProvider.kt
+++ b/src/main/kotlin/org/arend/project/ArendPreludeLibraryRootProvider.kt
@@ -2,21 +2,20 @@ package org.arend.project
 
 import com.intellij.icons.AllIcons
 import com.intellij.navigation.ItemPresentation
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.AdditionalLibraryRootsProvider
 import com.intellij.openapi.roots.SyntheticLibrary
 import com.intellij.openapi.vfs.VirtualFile
+import org.arend.typechecking.TypeCheckingService
 import javax.swing.Icon
 
 class ArendPreludeLibraryRootProvider: AdditionalLibraryRootsProvider() {
     override fun getAdditionalProjectLibraries(project: Project): MutableCollection<SyntheticLibrary> {
-        // TODO Enable after 2021.1.3 or 2021.2.
-        //  Disabled because of a platform bug that leads to exceptions.
-        return mutableListOf()
-//        return project.service<TypeCheckingService>().prelude?.virtualFile
-//            ?.let { PreludeLibrary(it) }
-//            ?.let { mutableListOf(it) }
-//            ?: mutableListOf()
+        return project.service<TypeCheckingService>().prelude?.virtualFile
+            ?.let { PreludeLibrary(it) }
+            ?.let { mutableListOf(it) }
+            ?: mutableListOf()
     }
 
     companion object {

--- a/src/test/kotlin/org/arend/project/ArendProjectViewTest.kt
+++ b/src/test/kotlin/org/arend/project/ArendProjectViewTest.kt
@@ -18,7 +18,9 @@ class ArendProjectViewTest : ArendTestBase() {
         doTest("""
             |-Project
             | PsiDirectory: src
-            | External Libraries
+            | -External Libraries
+            |  -arend-prelude
+            |   Prelude.ard
         """.trimMargin())
     }
 
@@ -36,6 +38,8 @@ class ArendProjectViewTest : ArendTestBase() {
                 |   -PsiDirectory: src
                 |    Function.ard
                 |   arend.yaml
+                |  -arend-prelude
+                |   Prelude.ard
             """.trimMargin())
         }
     }


### PR DESCRIPTION
The bug in the platform is fixed in 2021.2. I have enabled Prelude back, performed manual testing, and can confirm that there are no exceptions anymore.