### PR TITLE
Remove useless executors for Arend definitions

### DIFF
--- a/src/main/kotlin/org/arend/typechecking/execution/TypeCheckExecutor.kt
+++ b/src/main/kotlin/org/arend/typechecking/execution/TypeCheckExecutor.kt
@@ -1,0 +1,15 @@
+package org.arend.typechecking.execution
+
+import com.intellij.execution.executors.DefaultRunExecutor
+import org.arend.util.ArendBundle
+
+class TypeCheckExecutor : DefaultRunExecutor() {
+
+    override fun getDescription(): String = ArendBundle.message("arend.line.marker.description")
+
+    override fun getActionName(): String = ArendBundle.message("arend.line.marker.action.name")
+
+    override fun getStartActionText(): String = ArendBundle.message("arend.line.marker.action.text")
+
+    override fun getStartActionText(configurationName: String): String = configurationName
+}

--- a/src/main/kotlin/org/arend/typechecking/execution/TypeCheckRunLineMarkerContributor.kt
+++ b/src/main/kotlin/org/arend/typechecking/execution/TypeCheckRunLineMarkerContributor.kt
@@ -1,6 +1,6 @@
 package org.arend.typechecking.execution
 
-import com.intellij.execution.lineMarker.ExecutorAction
+import com.intellij.execution.actions.RunContextAction
 import com.intellij.execution.lineMarker.RunLineMarkerContributor
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.runReadAction
@@ -37,7 +37,7 @@ class TypeCheckRunLineMarkerContributor : RunLineMarkerContributor() {
                 { runReadAction {
                     if (parent.isValid) "Typecheck ${parent.fullName}" else "Typecheck definition"
                 } },
-                *ExecutorAction.getActions(1)
+                RunContextAction(TypeCheckExecutor())
         )
     }
 }

--- a/src/main/resources/messages/ArendBundle.properties
+++ b/src/main/resources/messages/ArendBundle.properties
@@ -25,6 +25,10 @@ arend.instance.addLocalInstance=Add local instance
 arend.instance.replaceWithLocalInstance=Replace local parameter with a local instance
 arend.instance.importInstance=Add instance import
 
+arend.line.marker.description=Typecheck selected definition
+arend.line.marker.action.name=Typecheck
+arend.line.marker.action.text=Typecheck
+
 arend.expression.swapInfixArguments=Swap infix operator arguments
 arend.expression.wrapInGoal=Wrap selected into a goal
 arend.expression.fillGoal=Fill goal


### PR DESCRIPTION
The intention popup is too noisy right now, so I made some cleanup.
![Peek 2021-08-20 21-33](https://user-images.githubusercontent.com/36202647/130278443-fe7b4ca1-4e38-4135-b2c5-50b71997cac5.gif)
