### PR TITLE
Disable inspections in injected files (#306)

### DIFF
--- a/src/main/kotlin/org/arend/inspection/ArendInspectionBase.kt
+++ b/src/main/kotlin/org/arend/inspection/ArendInspectionBase.kt
@@ -1,0 +1,16 @@
+package org.arend.inspection
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.util.castSafelyTo
+import org.arend.psi.ArendFile
+import org.arend.psi.ArendVisitor
+
+abstract class ArendInspectionBase : LocalInspectionTool() {
+    final override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor =
+            if (holder.file.castSafelyTo<ArendFile>()?.isInjected == true) PsiElementVisitor.EMPTY_VISITOR
+            else buildArendVisitor(holder, isOnTheFly)
+
+    abstract fun buildArendVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): ArendVisitor
+}

--- a/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
+++ b/src/main/kotlin/org/arend/inspection/RedundantParensInspection.kt
@@ -1,34 +1,34 @@
 package org.arend.inspection
 
-import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.LocalQuickFixOnPsiElement
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementVisitor
 import com.intellij.psi.PsiFile
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import com.intellij.util.castSafelyTo
 import org.arend.intention.binOp.BinOpIntentionUtil
-import org.arend.psi.parentArgumentAppExpr
 import org.arend.psi.*
 import org.arend.psi.ext.ArendFunctionalBody
+import org.arend.psi.parentArgumentAppExpr
 import org.arend.refactoring.unwrapParens
 import org.arend.util.ArendBundle
 import org.arend.util.isBinOp
 
-class RedundantParensInspection : LocalInspectionTool() {
-    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = object : ArendVisitor() {
-        override fun visitTuple(tuple: ArendTuple) {
-            super.visitTuple(tuple)
-            val expression = unwrapParens(tuple) ?: return
-            if (neverNeedsParens(expression) ||
-                    neverNeedsParensInParent(tuple) ||
-                    isApplicationUsedAsBinOpArgument(tuple, expression)) {
-                val message = ArendBundle.message("arend.inspection.redundant.parentheses.message")
-                holder.registerProblem(tuple, message, UnwrapParensFix(tuple))
+class RedundantParensInspection : ArendInspectionBase() {
+    override fun buildArendVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): ArendVisitor {
+        return object : ArendVisitor() {
+            override fun visitTuple(tuple: ArendTuple) {
+                super.visitTuple(tuple)
+                val expression = unwrapParens(tuple) ?: return
+                if (neverNeedsParens(expression) ||
+                        neverNeedsParensInParent(tuple) ||
+                        isApplicationUsedAsBinOpArgument(tuple, expression)) {
+                    val message = ArendBundle.message("arend.inspection.redundant.parentheses.message")
+                    holder.registerProblem(tuple, message, UnwrapParensFix(tuple))
+                }
             }
         }
     }


### PR DESCRIPTION
Updated version of #309 pull request. Here we disable inspections in all injected files, not only in Arend Errors.