### PR TITLE
Use single editor in ArendMessagesView (fixes #277)

### DIFF
--- a/src/main/kotlin/org/arend/actions/ArendGotoNextErrorAction.kt
+++ b/src/main/kotlin/org/arend/actions/ArendGotoNextErrorAction.kt
@@ -53,7 +53,7 @@ fun selectErrorFromEditor(project: Project, editor: Editor, file: ArendFile?, al
     for (arendError in arendErrors) {
         if (always || arendError.error.satisfies(service.autoScrollFromSource)) {
             val textRange = BasePass.getImprovedTextRange(arendError.error) ?: continue
-            if (textRange.contains(offset)) {
+            if (textRange.containsOffset(offset)) {
                 val messagesService = project.service<ArendMessagesService>()
                 messagesService.view?.tree?.select(arendError.error)
                 if (activate) {

--- a/src/main/kotlin/org/arend/highlight/ArendHighlightingPass.kt
+++ b/src/main/kotlin/org/arend/highlight/ArendHighlightingPass.kt
@@ -15,7 +15,6 @@ import org.arend.psi.ext.ArendIPNameImplMixin
 import org.arend.psi.ext.ArendReferenceElement
 import org.arend.psi.ext.PsiLocatedReferable
 import org.arend.psi.ext.TCDefinition
-import org.arend.psi.ext.impl.ArendGroup
 import org.arend.psi.ext.impl.ReferableAdapter
 import org.arend.psi.listener.ArendPsiChangeService
 import org.arend.quickfix.implementCoClause.IntentionBackEndVisitor
@@ -33,7 +32,7 @@ import org.arend.typechecking.execution.PsiElementComparator
 import org.arend.typechecking.order.Ordering
 import org.arend.typechecking.order.listener.CollectingOrderingListener
 
-class ArendHighlightingPass(file: ArendFile, private val group: ArendGroup, editor: Editor, textRange: TextRange, highlightInfoProcessor: HighlightInfoProcessor)
+class ArendHighlightingPass(file: ArendFile, editor: Editor, textRange: TextRange, highlightInfoProcessor: HighlightInfoProcessor)
     : BasePass(file, editor, "Arend resolver annotator", textRange, highlightInfoProcessor) {
 
     private val psiListenerService = myProject.service<ArendPsiChangeService>()
@@ -51,7 +50,7 @@ class ArendHighlightingPass(file: ArendFile, private val group: ArendGroup, edit
 
     override fun collectInformationWithProgress(progress: ProgressIndicator) {
         if (myProject.service<TypeCheckingService>().isLoaded) {
-            setProgressLimit(numberOfDefinitions(group).toLong())
+            setProgressLimit(numberOfDefinitions(file).toLong())
             collectInfo(progress)
         }
     }
@@ -162,7 +161,7 @@ class ArendHighlightingPass(file: ArendFile, private val group: ArendGroup, edit
 
                 advanceProgress(1)
             }
-        }).resolveGroup(group, group.scope)
+        }).resolveGroup(file, file.scope)
 
         concreteProvider.resolve = true
 

--- a/src/main/kotlin/org/arend/highlight/ArendHighlightingPassFactory.kt
+++ b/src/main/kotlin/org/arend/highlight/ArendHighlightingPassFactory.kt
@@ -20,7 +20,7 @@ class ArendHighlightingPassFactory : BasePassFactory<ArendFile>(ArendFile::class
     }
 
     override fun createPass(file: ArendFile, editor: Editor, textRange: TextRange) =
-        ArendHighlightingPass(file, file, editor, textRange, DefaultHighlightInfoProcessor())
+        ArendHighlightingPass(file, editor, textRange, DefaultHighlightInfoProcessor())
 
     override fun createHighlightingPass(file: PsiFile, editor: Editor) =
         if (file is ArendFile) {

--- a/src/main/kotlin/org/arend/injection/InjectedArendEditor.kt
+++ b/src/main/kotlin/org/arend/injection/InjectedArendEditor.kt
@@ -121,14 +121,13 @@ abstract class InjectedArendEditor(val project: Project, name: String, var treeE
             val document = editor.document
             runWriteAction {
                 document.setText(text)
+                val psi = PsiDocumentManager.getInstance(project).getPsiFile(document)
+                (psi as? PsiInjectionTextFile)?.apply {
+                    injectionRanges = visitor.textRanges
+                    scope = fileScope
+                    injectedExpressions = visitor.expressions
+                }
             }
-            val psi = PsiDocumentManager.getInstance(project).getPsiFile(document)
-            (psi as? PsiInjectionTextFile)?.apply {
-                injectionRanges = visitor.textRanges
-                scope = fileScope
-                injectedExpressions = visitor.expressions
-            }
-
             val support = EditorHyperlinkSupport.get(editor)
             support.clearHyperlinks()
             for (hyperlink in visitor.hyperlinks) {
@@ -172,11 +171,11 @@ abstract class InjectedArendEditor(val project: Project, name: String, var treeE
         ApplicationManager.getApplication().invokeLater {
             if (editor.isDisposed) return@invokeLater
             val document = editor.document
-            (PsiDocumentManager.getInstance(project).getPsiFile(document) as? PsiInjectionTextFile)?.apply {
-                injectionRanges.clear()
-                injectedExpressions.clear()
-            }
             runWriteAction {
+                (PsiDocumentManager.getInstance(project).getPsiFile(document) as? PsiInjectionTextFile)?.apply {
+                    injectionRanges.clear()
+                    injectedExpressions.clear()
+                }
                 document.setText("")
             }
         }

--- a/src/main/kotlin/org/arend/injection/InjectedArendEditor.kt
+++ b/src/main/kotlin/org/arend/injection/InjectedArendEditor.kt
@@ -31,22 +31,20 @@ import org.arend.psi.ext.impl.MetaAdapter
 import org.arend.resolving.ArendReferableConverter
 import org.arend.term.concrete.Concrete
 import org.arend.term.prettyprint.PrettyPrinterConfigWithRenamer
-import org.arend.toolWindow.errors.ArendPrintOptionsActionGroup
 import org.arend.toolWindow.errors.ArendPrintOptionsFilterAction
 import org.arend.toolWindow.errors.PrintOptionKind
 import org.arend.toolWindow.errors.tree.ArendErrorTreeElement
-import org.arend.ui.console.ArendClearConsoleAction
 import java.awt.BorderLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-class InjectedArendEditor(val project: Project, name: String, val treeElement: ArendErrorTreeElement?) {
-    private val editor: Editor?
+abstract class InjectedArendEditor(val project: Project, name: String, val treeElement: ArendErrorTreeElement?) {
+    protected val editor: Editor?
     private val panel: JPanel?
+    protected val actionGroup: DefaultActionGroup = DefaultActionGroup()
 
-    private val printOptionKind: PrintOptionKind
+    protected val printOptionKind: PrintOptionKind
         get() = when (treeElement?.highestError?.error?.level) {
-            null -> PrintOptionKind.CONSOLE_PRINT_OPTIONS
             GeneralError.Level.GOAL -> PrintOptionKind.GOAL_PRINT_OPTIONS
             else -> PrintOptionKind.ERROR_PRINT_OPTIONS
         }
@@ -64,13 +62,6 @@ class InjectedArendEditor(val project: Project, name: String, val treeElement: A
             panel = JPanel(BorderLayout())
             panel.add(editor.component, BorderLayout.CENTER)
 
-            val actionGroup = DefaultActionGroup()
-            if (treeElement != null) {
-                actionGroup.add(ActionManager.getInstance().getAction("Arend.PinErrorMessage"))
-            } else {
-                actionGroup.add(ArendClearConsoleAction(project, editor.contentComponent))
-            }
-            actionGroup.add(ArendPrintOptionsActionGroup(project, printOptionKind, treeElement?.errors?.any { it.error.hasExpressions() } ?: true))
             val toolbar = ActionManager.getInstance().createActionToolbar("ArendEditor.toolbar", actionGroup, false)
             toolbar.setTargetComponent(panel)
             panel.add(toolbar.component, BorderLayout.WEST)

--- a/src/main/kotlin/org/arend/injection/InjectedArendEditor.kt
+++ b/src/main/kotlin/org/arend/injection/InjectedArendEditor.kt
@@ -38,7 +38,7 @@ import java.awt.BorderLayout
 import javax.swing.JComponent
 import javax.swing.JPanel
 
-abstract class InjectedArendEditor(val project: Project, name: String, val treeElement: ArendErrorTreeElement?) {
+abstract class InjectedArendEditor(val project: Project, name: String, var treeElement: ArendErrorTreeElement?) {
     protected val editor: Editor?
     private val panel: JPanel?
     protected val actionGroup: DefaultActionGroup = DefaultActionGroup()

--- a/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesService.kt
+++ b/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesService.kt
@@ -41,8 +41,8 @@ class ArendMessagesService(private val project: Project) {
         }
     }
 
-    fun setActiveEditor() {
-        view?.setActiveEditor()
+    fun updateEditor() {
+        view?.updateEditor()
     }
 
     fun updateErrorText() {

--- a/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesView.kt
+++ b/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesView.kt
@@ -17,15 +17,14 @@ import com.intellij.ui.layout.panel
 import com.intellij.util.ui.tree.TreeUtil
 import org.arend.ArendIcons
 import org.arend.ext.error.GeneralError
-import org.arend.injection.InjectedArendEditor
+import org.arend.ext.error.MissingClausesError
 import org.arend.psi.ArendFile
+import org.arend.psi.ext.PsiConcreteReferable
 import org.arend.settings.ArendProjectSettings
 import org.arend.settings.ArendSettings
 import org.arend.toolWindow.errors.tree.*
 import org.arend.typechecking.error.ArendError
 import org.arend.typechecking.error.ErrorService
-import org.arend.ext.error.MissingClausesError
-import org.arend.psi.ext.PsiConcreteReferable
 import javax.swing.JPanel
 import javax.swing.event.TreeSelectionEvent
 import javax.swing.event.TreeSelectionListener
@@ -40,9 +39,9 @@ class ArendMessagesView(private val project: Project, toolWindow: ToolWindow) : 
 
     private val splitter = JBSplitter(false, 0.25f)
     private val emptyPanel = JPanel()
-    private var activeEditor: InjectedArendEditor? = null
+    private var activeEditor: ArendMessagesViewEditor? = null
 
-    private val errorEditors = HashMap<GeneralError, InjectedArendEditor>()
+    private val errorEditors = HashMap<GeneralError, ArendMessagesViewEditor>()
 
     init {
         ProjectManager.getInstance().addProjectManagerListener(project, this)
@@ -108,7 +107,7 @@ class ArendMessagesView(private val project: Project, toolWindow: ToolWindow) : 
                 for (arendError in treeElement.errors) {
                     configureError(arendError.error)
                 }
-                InjectedArendEditor(project, "Arend Messages", treeElement)
+                ArendMessagesViewEditor(project, treeElement)
             }
 
             activeEditor?.let {

--- a/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesView.kt
+++ b/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesView.kt
@@ -38,7 +38,7 @@ class ArendMessagesView(private val project: Project, toolWindow: ToolWindow) : 
 
     private val splitter = JBSplitter(false, 0.25f)
     private val emptyPanel = JPanel()
-    private var activeEditor: ArendMessagesViewEditor? = null
+    private var editor: ArendMessagesViewEditor? = null
 
     init {
         ProjectManager.getInstance().addProjectManagerListener(project, this)
@@ -78,36 +78,36 @@ class ArendMessagesView(private val project: Project, toolWindow: ToolWindow) : 
         if (project == this.project) {
             root.removeAllChildren()
             splitter.secondComponent = emptyPanel
-            activeEditor?.release()
-            activeEditor = null
+            editor?.release()
+            editor = null
         }
     }
 
     override fun valueChanged(e: TreeSelectionEvent?) {
         if (!project.service<ArendMessagesService>().isErrorTextPinned) {
-            setActiveEditor()
+            updateEditor()
         }
     }
 
-    fun setActiveEditor() {
+    fun updateEditor() {
         val treeElement = (tree.lastSelectedPathComponent as? DefaultMutableTreeNode)?.userObject as? ArendErrorTreeElement
         if (treeElement != null) {
-            if (activeEditor == null) {
-                activeEditor = ArendMessagesViewEditor(project, treeElement)
+            if (editor == null) {
+                editor = ArendMessagesViewEditor(project, treeElement)
             }
-            if (activeEditor?.treeElement != treeElement) {
+            if (editor?.treeElement != treeElement) {
                 for (arendError in treeElement.errors) {
                     configureError(arendError.error)
                 }
-                activeEditor?.update(treeElement)
+                editor?.update(treeElement)
             }
-            splitter.secondComponent = activeEditor?.component ?: emptyPanel
+            splitter.secondComponent = editor?.component ?: emptyPanel
         } else {
-            val activeError = activeEditor?.treeElement?.sampleError
+            val activeError = editor?.treeElement?.sampleError
             if (activeError != null) {
                 val def = activeError.definition
                 if (def == null || !tree.containsNode(def)) {
-                    activeEditor?.clear()
+                    editor?.clear()
                     splitter.secondComponent = emptyPanel
                 }
             }
@@ -115,7 +115,7 @@ class ArendMessagesView(private val project: Project, toolWindow: ToolWindow) : 
     }
 
     fun updateErrorText() {
-        activeEditor?.updateErrorText()
+        editor?.updateErrorText()
     }
 
     private fun configureError(error: GeneralError) {

--- a/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesViewEditor.kt
+++ b/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesViewEditor.kt
@@ -11,6 +11,19 @@ class ArendMessagesViewEditor(project: Project, treeElement: ArendErrorTreeEleme
         setupActions()
     }
 
+    fun update(newTreeElement: ArendErrorTreeElement) {
+        treeElement = newTreeElement
+        updateErrorText()
+        actionGroup.removeAll()
+        setupActions()
+    }
+
+    fun clear() {
+        clearText()
+        actionGroup.removeAll()
+        treeElement = null
+    }
+
     private fun setupActions() {
         actionGroup.add(ActionManager.getInstance().getAction("Arend.PinErrorMessage"))
         val enablePrintOptions = treeElement?.errors?.any { it.error.hasExpressions() } ?: false

--- a/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesViewEditor.kt
+++ b/src/main/kotlin/org/arend/toolWindow/errors/ArendMessagesViewEditor.kt
@@ -1,0 +1,19 @@
+package org.arend.toolWindow.errors
+
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.project.Project
+import org.arend.injection.InjectedArendEditor
+import org.arend.toolWindow.errors.tree.ArendErrorTreeElement
+
+class ArendMessagesViewEditor(project: Project, treeElement: ArendErrorTreeElement)
+    : InjectedArendEditor(project, "Arend Messages", treeElement) {
+    init {
+        setupActions()
+    }
+
+    private fun setupActions() {
+        actionGroup.add(ActionManager.getInstance().getAction("Arend.PinErrorMessage"))
+        val enablePrintOptions = treeElement?.errors?.any { it.error.hasExpressions() } ?: false
+        actionGroup.add(ArendPrintOptionsActionGroup(project, printOptionKind, enablePrintOptions))
+    }
+}

--- a/src/main/kotlin/org/arend/toolWindow/errors/ArendPinErrorAction.kt
+++ b/src/main/kotlin/org/arend/toolWindow/errors/ArendPinErrorAction.kt
@@ -15,7 +15,7 @@ class ArendPinErrorAction: ToggleAction("Pin message", "When the message is pinn
     override fun setSelected(e: AnActionEvent, state: Boolean) {
         val service = getMessagesService(e)
         service?.isErrorTextPinned = state
-        if (!state) service?.setActiveEditor()
+        if (!state) service?.updateEditor()
     }
 
     private fun getMessagesService(e: AnActionEvent): ArendMessagesService? =

--- a/src/main/kotlin/org/arend/ui/console/ArendConsoleView.kt
+++ b/src/main/kotlin/org/arend/ui/console/ArendConsoleView.kt
@@ -7,11 +7,10 @@ import com.intellij.openapi.wm.RegisterToolWindowTask
 import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
 import org.arend.ArendIcons
-import org.arend.injection.InjectedArendEditor
 
 class ArendConsoleView(project: Project) : ProjectManagerListener {
     val toolWindow = ToolWindowManager.getInstance(project).registerToolWindow(RegisterToolWindowTask(CONSOLE_ID, ToolWindowAnchor.RIGHT, canWorkInDumbMode = false))
-    val editor = InjectedArendEditor(project, CONSOLE_ID, null)
+    val editor = ArendConsoleViewEditor(project)
 
     init {
         ProjectManager.getInstance().addProjectManagerListener(project, this)

--- a/src/main/kotlin/org/arend/ui/console/ArendConsoleViewEditor.kt
+++ b/src/main/kotlin/org/arend/ui/console/ArendConsoleViewEditor.kt
@@ -1,0 +1,15 @@
+package org.arend.ui.console
+
+import com.intellij.openapi.project.Project
+import org.arend.injection.InjectedArendEditor
+import org.arend.toolWindow.errors.ArendPrintOptionsActionGroup
+import org.arend.toolWindow.errors.PrintOptionKind
+
+class ArendConsoleViewEditor(project: Project) : InjectedArendEditor(project, ArendConsoleView.CONSOLE_ID, null) {
+    init {
+        if (editor != null) {
+            actionGroup.add(ArendClearConsoleAction(project, editor.contentComponent))
+            actionGroup.add(ArendPrintOptionsActionGroup(project, PrintOptionKind.CONSOLE_PRINT_OPTIONS))
+        }
+    }
+}


### PR DESCRIPTION
This pull request solves the following bug: #277. Here is why the bug happens:
1. `TypecheckerPassFactory.createPass` has a branch that doesn't create the pass, but calls `ArendMessagesView.update` (via `ArendMessagesService.update`).
2. That call can release the editor used in `ArendMessagesView`.
3. The Platform's subsystem that runs highlighting passes does not apply the results of the passes because some editor was released. This happens in `PassExecutorService#applyInformationToEditorsLater`.

To solve the issue, I rewrote `ArendMessagesView`. Now, instead of using a separate editor for each error, it uses a single one for all errors. So we never release it (as long as the current project is open).

Here is how it looks like. Before the fix:

![paste-before](https://user-images.githubusercontent.com/5653229/135271031-838b4d78-e8dd-44dd-a3d4-57b38295c3f0.gif)

After the fix:

![paste-after](https://user-images.githubusercontent.com/5653229/135274762-4ca9d7b7-4564-43eb-adbc-6cddc2d51ed9.gif)

So, basically, typechecking results are immediately shown both in Arend Errors and in the editor, you do not need to move the caret to see them.