### PR TITLE
Respect fixity in Smart Selection actions

### DIFF
--- a/src/main/kotlin/org/arend/actions/ArendSmartSelectProvider.kt
+++ b/src/main/kotlin/org/arend/actions/ArendSmartSelectProvider.kt
@@ -1,0 +1,121 @@
+package org.arend.actions
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.ex.util.EditorUtil
+import com.intellij.openapi.ide.SmartSelectProvider
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parents
+import com.intellij.refactoring.suggested.endOffset
+import com.intellij.refactoring.suggested.startOffset
+import org.arend.psi.ArendExpr
+import org.arend.psi.ArendFile
+import org.arend.resolving.util.parseBinOp
+import org.arend.term.concrete.Concrete
+
+class ArendSmartSelectProvider : SmartSelectProvider<ArendSmartSelectProvider.Context> {
+
+    data class Context(val file: ArendFile, val editor: Editor, val selectionRange: TextRange)
+
+    override fun increaseSelection(source: Context) {
+        val (file, editor, selectionRange) = source
+        val elementAtSelection = file.findElementAt(selectionRange.startOffset) ?: return
+        val defaultParent = elementAtSelection
+                .parents(true)
+                .firstOrNull { it.textRange.strictlyContains(selectionRange) }
+                ?: return
+        if (defaultParent is ArendExpr) {
+            val refinedParent = findClosestNodeInBinOp(defaultParent) { it.strictlyContains(selectionRange) }
+            editor.selectionModel.setSelection(refinedParent.startOffset, refinedParent.endOffset)
+        } else {
+            editor.selectionModel.setSelection(defaultParent.startOffset, defaultParent.endOffset)
+        }
+    }
+
+    override fun decreaseSelection(source: Context) {
+        val (file, editor, selectionRange) = source
+        if (selectionRange.startOffset == selectionRange.endOffset) {
+            return
+        }
+        val caretOffset = editor.caretModel.offset
+        val elementAtCaret = file.findElementAt(caretOffset)
+        if (elementAtCaret == null) {
+            editor.selectionModel.setSelection(caretOffset, caretOffset)
+            return
+        }
+        val selectionOwner = elementAtCaret.parents(true).first { it.textRange.contains(selectionRange) }
+
+        if (selectionOwner is ArendExpr) {
+            val candidateRanges = mutableListOf<TextRange>()
+            val fallbackRange = findClosestNodeInBinOp(selectionOwner) {
+                if (selectionRange.strictlyContains(it) && it.contains(caretOffset)) candidateRanges.add(it)
+                false
+            }
+            val coarsestChild = candidateRanges.lastOrNull()
+            if (fallbackRange != selectionOwner.textRange && coarsestChild != null) {
+                editor.selectionModel.setSelection(coarsestChild.startOffset, coarsestChild.endOffset)
+                return
+            }
+        }
+        val coarsestChildNode = elementAtCaret.parents(true).lastOrNull { selectionRange.strictlyContains(it.textRange) }
+        if (coarsestChildNode == null) {
+            editor.selectionModel.setSelection(caretOffset, caretOffset)
+        } else {
+            editor.selectionModel.setSelection(coarsestChildNode.startOffset, coarsestChildNode.endOffset)
+        }
+    }
+
+    override fun getSource(context: DataContext?): Context? {
+        val project = context?.getData("project") as? Project ?: return null
+        if (DumbService.isDumb(project)) {
+            return null
+        }
+        val file = context.getData("psi.File") as? ArendFile ?: return null
+        val editor = context.getData("editor") as? Editor ?: return null
+        // the platform contains some logic on expanding selection having an empty one,
+        // so we'll handle what goes after
+        val selection = EditorUtil.getSelectionInAnyMode(editor).takeIf { !it.isEmpty } ?: return null
+        return Context(file, editor, selection)
+    }
+
+    private fun findClosestNodeInBinOp(defaultParent: ArendExpr, predicate: (TextRange) -> Boolean): TextRange {
+        val binOp = parseBinOp(defaultParent) ?: return defaultParent.textRange
+        return visitParsedBinOp(binOp, predicate) ?: defaultParent.textRange
+    }
+
+    private fun visitParsedBinOp(concrete: Concrete.Expression, predicate: (TextRange) -> Boolean): TextRange? {
+        var result: TextRange? = null
+
+        fun doVisit(concrete: Concrete.Expression): TextRange? {
+            when (concrete) {
+                is Concrete.AppExpression -> {
+                    val childRanges = mutableListOf<TextRange>()
+                    for (arg in concrete.arguments) {
+                        val argRange = doVisit(arg.expression) ?: return null
+                        if (predicate(argRange)) {
+                            result = argRange
+                            return null
+                        }
+                        childRanges.add(argRange)
+                    }
+                    childRanges.add((concrete.function.data as PsiElement).textRange)
+                    return TextRange(childRanges.minOf { it.startOffset }, childRanges.maxOf { it.endOffset })
+                }
+                is Concrete.HoleExpression -> {
+                    return (concrete.data as PsiElement).textRange
+                }
+                else -> {
+                    return null
+                }
+            }
+        }
+
+        doVisit(concrete)
+        return result
+    }
+
+    private fun TextRange.strictlyContains(other: TextRange): Boolean = this != other && this.contains(other)
+}

--- a/src/main/kotlin/org/arend/actions/ArendSmartSelectProvider.kt
+++ b/src/main/kotlin/org/arend/actions/ArendSmartSelectProvider.kt
@@ -50,12 +50,12 @@ class ArendSmartSelectProvider : SmartSelectProvider<ArendSmartSelectProvider.Co
 
         if (selectionOwner is ArendExpr) {
             val candidateRanges = mutableListOf<TextRange>()
-            val fallbackRange = findClosestNodeInBinOp(selectionOwner) {
+            findClosestNodeInBinOp(selectionOwner) {
                 if (selectionRange.strictlyContains(it) && it.contains(caretOffset)) candidateRanges.add(it)
                 false
             }
             val coarsestChild = candidateRanges.lastOrNull()
-            if (fallbackRange != selectionOwner.textRange && coarsestChild != null) {
+            if (coarsestChild != null) {
                 editor.selectionModel.setSelection(coarsestChild.startOffset, coarsestChild.endOffset)
                 return
             }

--- a/src/main/kotlin/org/arend/resolving/util/BinOpParser.kt
+++ b/src/main/kotlin/org/arend/resolving/util/BinOpParser.kt
@@ -59,3 +59,16 @@ fun parseBinOp(data: Any?, left: Abstract.Expression, sequence: Collection<Abstr
     return BinOpParser(DummyErrorReporter.INSTANCE).parse(Concrete.BinOpSequenceExpression(data, concreteSeq, null))
 }
 
+/**
+ * Attempts to parse abstract expression assuming it is already a bin op sequence.
+ */
+fun parseBinOp(expr : Abstract.Expression) : Concrete.Expression? {
+    var result : Concrete.Expression? = null
+    expr.accept(object : BaseAbstractExpressionVisitor<Unit, Nothing?>(null){
+        override fun visitBinOpSequence(data: Any?, left: Abstract.Expression, sequence: MutableCollection<out Abstract.BinOpSequenceElem>, params: Unit?): Nothing? {
+            result = parseBinOp(left, sequence)
+            return null
+        }
+    }, Unit)
+    return result
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -159,6 +159,10 @@
 
         <completion.confidence language="Arend" implementationClass="org.arend.codeInsight.completion.ArendCompletionConfidence" id="arendCompletion" />
 
+        <!-- Selection -->
+
+        <smartSelectProvider implementation="org.arend.actions.ArendSmartSelectProvider"/>
+
         <!-- Support arend.yaml -->
 
         <completion.contributor language="yaml" implementationClass="org.arend.yaml.codeInsight.YAMLCompletionContributor"/>


### PR DESCRIPTION
This PR makes "Extend Selection" and "Shrink Selection" actions a bit more smart: they didn't recognize bin op sequences previously. Here is a demo.

Before:
![Peek 2021-09-30 20-38](https://user-images.githubusercontent.com/36202647/135505297-42fef506-50f7-499d-93cc-da96c57f6479.gif)

After:
![Peek 2021-09-30 20-39](https://user-images.githubusercontent.com/36202647/135505358-da5c5dfc-64bf-4b76-95c0-4e84172739d5.gif)

