### PR TITLE
Handle goals with arguments in "Generate function" intention

### DIFF
--- a/src/main/kotlin/org/arend/intention/AbstractGenerateFunctionIntention.kt
+++ b/src/main/kotlin/org/arend/intention/AbstractGenerateFunctionIntention.kt
@@ -64,7 +64,7 @@ abstract class AbstractGenerateFunctionIntention : BaseIntentionAction() {
         file ?: return
         val selectionResult = extractSelectionData(file, editor, project) ?: return
         val expressions = listOfNotNull(selectionResult.expectedType, selectionResult.body)
-        val freeVariables = FreeVariablesWithDependenciesCollector.collectFreeVariables(expressions)
+        val freeVariables = FreeVariablesWithDependenciesCollector.collectFreeVariables(expressions).filter { freeArg -> freeArg.first.name !in selectionResult.additionalArguments.map { it.first.name } }
         performRefactoring(freeVariables, selectionResult, editor, project)
     }
 

--- a/src/main/kotlin/org/arend/intention/AbstractGenerateFunctionIntention.kt
+++ b/src/main/kotlin/org/arend/intention/AbstractGenerateFunctionIntention.kt
@@ -55,7 +55,8 @@ abstract class AbstractGenerateFunctionIntention : BaseIntentionAction() {
         val rangeOfReplacement: TextRange,
         val selectedConcrete : Concrete.Expression?,
         val identifier: String?,
-        val body: Expression?
+        val body: Expression?,
+        val additionalArguments: List<Pair<TypedBinding, ParameterExplicitnessState>> = emptyList()
     )
 
     override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
@@ -111,7 +112,7 @@ abstract class AbstractGenerateFunctionIntention : BaseIntentionAction() {
             }
         }
 
-        val parameters = freeVariables.collapseTelescopes().joinToString("") { (bindings, explicitness) ->
+        val parameters = (freeVariables + selection.additionalArguments).collapseTelescopes().joinToString("") { (bindings, explicitness) ->
             " ${explicitness.openingBrace}${bindings.joinToString(" ") { it.name }} : ${prettyPrinter(bindings.first().typeExpr, false)}${explicitness.closingBrace}"
         }
 

--- a/src/main/kotlin/org/arend/intention/AbstractGenerateFunctionIntention.kt
+++ b/src/main/kotlin/org/arend/intention/AbstractGenerateFunctionIntention.kt
@@ -63,8 +63,9 @@ abstract class AbstractGenerateFunctionIntention : BaseIntentionAction() {
         editor ?: return
         file ?: return
         val selectionResult = extractSelectionData(file, editor, project) ?: return
-        val expressions = listOfNotNull(selectionResult.expectedType, selectionResult.body)
-        val freeVariables = FreeVariablesWithDependenciesCollector.collectFreeVariables(expressions).filter { freeArg -> freeArg.first.name !in selectionResult.additionalArguments.map { it.first.name } }
+        val expressions = listOfNotNull(selectionResult.expectedType, selectionResult.body, *selectionResult.additionalArguments.map { it.first.typeExpr }.toTypedArray())
+        val freeVariables = FreeVariablesWithDependenciesCollector.collectFreeVariables(expressions)
+                .filter { freeArg -> freeArg.first.name !in selectionResult.additionalArguments.map { it.first.name } }
         performRefactoring(freeVariables, selectionResult, editor, project)
     }
 

--- a/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
+++ b/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
@@ -5,11 +5,18 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.parentOfType
+import org.arend.core.context.binding.TypedBinding
+import org.arend.core.expr.DefCallExpression
+import org.arend.core.expr.Expression
+import org.arend.core.expr.PiExpression
+import org.arend.psi.ArendArgumentAppExpr
 import org.arend.psi.ArendGoal
+import org.arend.psi.ext.ArendCompositeElement
 import org.arend.refactoring.tryCorrespondedSubExpr
 import org.arend.typechecking.error.ErrorService
 import org.arend.typechecking.error.local.GoalError
 import org.arend.util.ArendBundle
+import org.arend.util.ParameterExplicitnessState
 
 class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
 
@@ -30,9 +37,41 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
         val arendError = errorService.errors[goal.containingFile]?.firstOrNull { it.cause == goal }?.error as? GoalError
                 ?: return null
         val goalType = (arendError as? GoalError)?.expectedType
+        val appParent = goal.parentOfType<ArendArgumentAppExpr>()?.takeIf { it.atomFieldsAcc?.atom?.literal?.goal === goal }
+        val additionalArguments = mutableListOf<Pair<TypedBinding, ParameterExplicitnessState>>()
+        var currentGoalType : Expression? = goalType
+        if (appParent != null && goalType is PiExpression) {
+            val forbiddenNames = mutableSetOf<String>()
+            val typecheckedUserArguments = appParent.argumentList.map { tryCorrespondedSubExpr(it.textRange, file, project, editor) to it.isExplicit }
+            for ((argResult, explicitness) in typecheckedUserArguments) {
+                currentGoalType as PiExpression
+                val expectedType = currentGoalType.parameters.typeExpr
+                val explicitnessState = if (explicitness) ParameterExplicitnessState.EXPLICIT else ParameterExplicitnessState.IMPLICIT
+                if (argResult == null) {
+                    additionalArguments.add(TypedBinding("_", expectedType) to explicitnessState)
+                } else {
+                    additionalArguments.add(TypedBinding(suggestParameterName(forbiddenNames, goal, expectedType), expectedType) to explicitnessState)
+                }
+                currentGoalType = currentGoalType.codomain
+            }
+        }
         val goalExpr = goal.expr?.let {
             tryCorrespondedSubExpr(it.textRange, file, project, editor)
         }?.subCore
-        return SelectionResult(goalType, goal, goal.textRange, null, goal.defIdentifier?.name, goalExpr)
+        return SelectionResult(currentGoalType, goal, goal.textRange, null, goal.defIdentifier?.name, goalExpr, additionalArguments)
+    }
+
+    private fun suggestParameterName(forbiddenNames: MutableSet<String>, context : ArendCompositeElement, type : Expression) : String {
+        var candidate = if (type is DefCallExpression) {
+            val definitionName = type.definition.name
+                    if (definitionName[0].isLetter()) definitionName[0].lowercase() else "x"
+        } else {
+            "x"
+        }
+        while(context.scope.resolveName(candidate) != null) {
+            candidate += '\''
+        }
+        forbiddenNames.add(candidate)
+        return candidate
     }
 }

--- a/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
+++ b/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
@@ -3,17 +3,20 @@ package org.arend.intention
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
+import org.arend.core.context.binding.Binding
 import org.arend.core.context.binding.TypedBinding
+import org.arend.core.context.param.TypedSingleDependentLink
 import org.arend.core.expr.DefCallExpression
 import org.arend.core.expr.Expression
 import org.arend.core.expr.PiExpression
 import org.arend.core.expr.ReferenceExpression
+import org.arend.core.expr.type.TypeExpression
 import org.arend.extImpl.UncheckedExpressionImpl
-import org.arend.psi.ArendArgument
 import org.arend.psi.ArendArgumentAppExpr
 import org.arend.psi.ArendAtomFieldsAcc
 import org.arend.psi.ArendGoal
@@ -22,13 +25,10 @@ import org.arend.psi.ext.ArendFunctionalDefinition
 import org.arend.refactoring.tryCorrespondedSubExpr
 import org.arend.term.concrete.BaseConcreteExpressionVisitor
 import org.arend.term.concrete.Concrete
-import org.arend.term.concrete.ConcreteExpressionVisitor
 import org.arend.typechecking.error.ErrorService
 import org.arend.typechecking.error.local.GoalError
 import org.arend.util.ArendBundle
-import org.arend.util.ParameterExplicitnessState
 import org.arend.util.appExprToConcrete
-import kotlin.math.exp
 
 class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
 
@@ -49,52 +49,74 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
         val arendError = errorService.errors[goal.containingFile]?.firstOrNull { it.cause == goal }?.error as? GoalError
                 ?: return null
         val goalType = (arendError as? GoalError)?.expectedType
-        val appParent = goal.parentOfType<ArendArgumentAppExpr>()?.takeIf { it.atomFieldsAcc?.atom?.literal?.goal === goal }
-        val additionalArguments = mutableListOf<Pair<TypedBinding, ParameterExplicitnessState>>()
-        var targetCodomain = goalType?.deepCodomain()
-        if (appParent != null && goalType is PiExpression) {
-            var currentGoalType : Expression? = goalType
-            val forbiddenNames = mutableSetOf<String>()
-            val actualArguments = getBinOpAwareArguments(goal, appParent)
-            val typecheckedUserArguments = actualArguments.map { (elem, explicit) -> tryCorrespondedSubExpr(elem.textRange, file, project, editor) to explicit }
-            for ((argResult, explicitness) in typecheckedUserArguments) {
-                currentGoalType as PiExpression
-                val expectedType = currentGoalType.parameters.typeExpr
-                val explicitnessState = if (explicitness) ParameterExplicitnessState.EXPLICIT else ParameterExplicitnessState.IMPLICIT
-                if (argResult == null) {
-                    additionalArguments.add(TypedBinding("_", expectedType) to explicitnessState)
-                } else {
-                    val contextElement = goal.parentOfType<ArendFunctionalDefinition>() ?: goal
-                    val newBinding = TypedBinding(suggestParameterName(forbiddenNames, contextElement, expectedType), expectedType)
-                    additionalArguments.add(newBinding to explicitnessState)
-                    val uncheckedTargetExpression = targetCodomain?.replaceSubexpressions { expr ->
-                        if (expr == argResult.subCore) {
-                            ReferenceExpression(newBinding)
-                        } else {
-                            null
-                        }
-                    }
-                    targetCodomain = UncheckedExpressionImpl.extract(uncheckedTargetExpression)
-                }
-                currentGoalType = currentGoalType.codomain
-            }
-        }
+        val (modifiedType, customArguments) = getCustomArguments(goal, goalType) { tryCorrespondedSubExpr(it, file, project, editor)?.subCore }
         val goalExpr = goal.expr?.let {
             tryCorrespondedSubExpr(it.textRange, file, project, editor)
         }?.subCore
-        return SelectionResult(targetCodomain, goal, goal.textRange, null, goal.defIdentifier?.name, goalExpr, additionalArguments)
+        return SelectionResult(modifiedType ?: goalType,
+                goal,
+                goal.textRange,
+                null,
+                goal.defIdentifier?.name,
+                goalExpr,
+                customArguments)
     }
 
-    private fun Expression.deepCodomain() : Expression =
-        if (this is PiExpression) codomain.deepCodomain() else this
+    private fun getCustomArguments(goal: ArendGoal, goalType: Expression?, typechecker: (TextRange) -> Expression?): Pair<Expression?, List<TypedSingleDependentLink>> {
+        val emptyResult = null to emptyList<TypedSingleDependentLink>()
+        if (goalType !is PiExpression) return emptyResult
+        val goalApplication = goal.parentOfType<ArendArgumentAppExpr>()?.takeIf {
+            it.atomFieldsAcc?.isEffectivelyGoal(goal) ?: false
+        } ?: return emptyResult
+        return unrollGoalType(goal, goalType, goalApplication, typechecker)
+    }
 
-    private fun getBinOpAwareArguments(goal: ArendGoal, psiAppExpr: ArendArgumentAppExpr) : List<Pair<PsiElement, Boolean>> {
-        val parsedAppExpr = appExprToConcrete(psiAppExpr, true) ?: return psiAppExpr.argumentList.map { it to it.isExplicit }
+    private fun unrollGoalType(goal: ArendGoal, goalType: Expression, goalApplication: ArendArgumentAppExpr, typechecker: (TextRange) -> Expression?): Pair<Expression, List<TypedSingleDependentLink>> {
+        var currentGoalType: Expression = goalType
+        val forbiddenNames = mutableSetOf<String>()
+        val customArguments = mutableListOf<TypedSingleDependentLink>()
+        val reverseSubstitution: MutableMap<Expression, Binding> = LinkedHashMap()
+        for ((arg, isExplicit) in computeGoalArguments(goal, goalApplication)) {
+            currentGoalType as PiExpression
+            val expectedType = currentGoalType.parameters.typeExpr
+            val typechecked = typechecker(arg.textRange)
+            if (typechecked == null) {
+                customArguments.add(TypedSingleDependentLink(isExplicit, "_", TypeExpression(expectedType, null)))
+            } else {
+                val contextElement = goal.parentOfType<ArendFunctionalDefinition>() ?: goal
+                val newBinding = TypedBinding(suggestParameterName(forbiddenNames, contextElement, expectedType), expectedType)
+                customArguments.add(TypedSingleDependentLink(isExplicit, newBinding.name, TypeExpression(expectedType, null)))
+                reverseSubstitution[typechecked] = newBinding
+            }
+            currentGoalType = currentGoalType.codomain
+        }
+        val substitutedType = performReverseSubstitution(currentGoalType, reverseSubstitution)
+        return substitutedType to customArguments
+    }
+
+    private fun performReverseSubstitution(type: Expression, reverseSubstitution: Map<Expression, Binding>): Expression {
+        var currentType = type
+        for ((subExpr, binding) in reverseSubstitution) {
+            val uncheckedTargetExpression = currentType.replaceSubexpressions {
+                if (it == subExpr) {
+                    ReferenceExpression(binding)
+                } else {
+                    null
+                }
+            }
+            currentType = UncheckedExpressionImpl.extract(uncheckedTargetExpression)
+        }
+        return currentType
+    }
+
+    private fun computeGoalArguments(goal: ArendGoal, psiAppExpr: ArendArgumentAppExpr): List<Pair<PsiElement, Boolean>> {
+        val parsedAppExpr = appExprToConcrete(psiAppExpr, true)
+                ?: return psiAppExpr.argumentList.map { it to it.isExplicit }
         var result = emptyList<Pair<PsiElement, Boolean>>()
         parsedAppExpr.accept(object : BaseConcreteExpressionVisitor<Unit>() {
             override fun visitApp(expr: Concrete.AppExpression, params: Unit?): Concrete.Expression {
                 val functionPsi = expr.function.data as PsiElement
-                if (functionPsi is ArendAtomFieldsAcc && PsiTreeUtil.isAncestor(functionPsi, goal, false)) {
+                if (functionPsi.isEffectivelyGoal(goal)) {
                     result = expr.arguments.map { it.expression.data as PsiElement to it.isExplicit }
                     return expr
                 }
@@ -104,10 +126,13 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
         return result
     }
 
-    private fun suggestParameterName(forbiddenNames: MutableSet<String>, context : ArendCompositeElement, type : Expression) : String {
-        var candidate = if (type is DefCallExpression) {
-            val definitionName = type.definition.name
-                    if (definitionName[0].isLetter()) definitionName[0].lowercase() else "x"
+    private fun PsiElement.isEffectivelyGoal(goal: PsiElement): Boolean {
+        return this is ArendAtomFieldsAcc && PsiTreeUtil.isAncestor(this, goal, false)
+    }
+
+    private fun suggestParameterName(forbiddenNames: MutableSet<String>, context: ArendCompositeElement, type: Expression): String {
+        var candidate = if (type is DefCallExpression && type.definition.name[0].isLetter()) {
+            type.definition.name[0].lowercase()
         } else {
             "x"
         }

--- a/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
+++ b/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
@@ -136,7 +136,7 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
         } else {
             "x"
         }
-        while (context.scope.resolveName(candidate) != null) {
+        while (forbiddenNames.contains(candidate) || context.scope.resolveName(candidate) != null) {
             candidate += '\''
         }
         forbiddenNames.add(candidate)

--- a/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
+++ b/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
@@ -3,7 +3,9 @@ package org.arend.intention
 import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
 import org.arend.core.context.binding.TypedBinding
 import org.arend.core.expr.DefCallExpression
@@ -11,16 +13,22 @@ import org.arend.core.expr.Expression
 import org.arend.core.expr.PiExpression
 import org.arend.core.expr.ReferenceExpression
 import org.arend.extImpl.UncheckedExpressionImpl
+import org.arend.psi.ArendArgument
 import org.arend.psi.ArendArgumentAppExpr
+import org.arend.psi.ArendAtomFieldsAcc
 import org.arend.psi.ArendGoal
 import org.arend.psi.ext.ArendCompositeElement
 import org.arend.psi.ext.ArendFunctionalDefinition
-import org.arend.refactoring.binding
 import org.arend.refactoring.tryCorrespondedSubExpr
+import org.arend.term.concrete.BaseConcreteExpressionVisitor
+import org.arend.term.concrete.Concrete
+import org.arend.term.concrete.ConcreteExpressionVisitor
 import org.arend.typechecking.error.ErrorService
 import org.arend.typechecking.error.local.GoalError
 import org.arend.util.ArendBundle
 import org.arend.util.ParameterExplicitnessState
+import org.arend.util.appExprToConcrete
+import kotlin.math.exp
 
 class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
 
@@ -47,7 +55,8 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
         if (appParent != null && goalType is PiExpression) {
             var currentGoalType : Expression? = goalType
             val forbiddenNames = mutableSetOf<String>()
-            val typecheckedUserArguments = appParent.argumentList.map { tryCorrespondedSubExpr(it.textRange, file, project, editor) to it.isExplicit }
+            val actualArguments = getBinOpAwareArguments(goal, appParent)
+            val typecheckedUserArguments = actualArguments.map { (elem, explicit) -> tryCorrespondedSubExpr(elem.textRange, file, project, editor) to explicit }
             for ((argResult, explicitness) in typecheckedUserArguments) {
                 currentGoalType as PiExpression
                 val expectedType = currentGoalType.parameters.typeExpr
@@ -78,6 +87,22 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
 
     private fun Expression.deepCodomain() : Expression =
         if (this is PiExpression) codomain.deepCodomain() else this
+
+    private fun getBinOpAwareArguments(goal: ArendGoal, psiAppExpr: ArendArgumentAppExpr) : List<Pair<PsiElement, Boolean>> {
+        val parsedAppExpr = appExprToConcrete(psiAppExpr, true) ?: return psiAppExpr.argumentList.map { it to it.isExplicit }
+        var result = emptyList<Pair<PsiElement, Boolean>>()
+        parsedAppExpr.accept(object : BaseConcreteExpressionVisitor<Unit>() {
+            override fun visitApp(expr: Concrete.AppExpression, params: Unit?): Concrete.Expression {
+                val functionPsi = expr.function.data as PsiElement
+                if (functionPsi is ArendAtomFieldsAcc && PsiTreeUtil.isAncestor(functionPsi, goal, false)) {
+                    result = expr.arguments.map { it.expression.data as PsiElement to it.isExplicit }
+                    return expr
+                }
+                return super.visitApp(expr, params)
+            }
+        }, Unit)
+        return result
+    }
 
     private fun suggestParameterName(forbiddenNames: MutableSet<String>, context : ArendCompositeElement, type : Expression) : String {
         var candidate = if (type is DefCallExpression) {

--- a/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
+++ b/src/main/kotlin/org/arend/intention/GenerateFunctionFromGoalIntention.kt
@@ -14,6 +14,7 @@ import org.arend.extImpl.UncheckedExpressionImpl
 import org.arend.psi.ArendArgumentAppExpr
 import org.arend.psi.ArendGoal
 import org.arend.psi.ext.ArendCompositeElement
+import org.arend.psi.ext.ArendFunctionalDefinition
 import org.arend.refactoring.binding
 import org.arend.refactoring.tryCorrespondedSubExpr
 import org.arend.typechecking.error.ErrorService
@@ -54,7 +55,8 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
                 if (argResult == null) {
                     additionalArguments.add(TypedBinding("_", expectedType) to explicitnessState)
                 } else {
-                    val newBinding = TypedBinding(suggestParameterName(forbiddenNames, goal, expectedType), expectedType)
+                    val contextElement = goal.parentOfType<ArendFunctionalDefinition>() ?: goal
+                    val newBinding = TypedBinding(suggestParameterName(forbiddenNames, contextElement, expectedType), expectedType)
                     additionalArguments.add(newBinding to explicitnessState)
                     val uncheckedTargetExpression = targetCodomain?.replaceSubexpressions { expr ->
                         if (expr == argResult.subCore) {
@@ -84,7 +86,7 @@ class GenerateFunctionFromGoalIntention : AbstractGenerateFunctionIntention() {
         } else {
             "x"
         }
-        while(context.scope.resolveName(candidate) != null) {
+        while (context.scope.resolveName(candidate) != null) {
             candidate += '\''
         }
         forbiddenNames.add(candidate)

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -139,4 +139,16 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
         
         \func foo-lemma (n : Nat) : Nat => {?}
         """)
+
+    fun `test goal with arguments, replacing in type`() = doTest("""
+        \data Unit | unit
+
+        \func foo (f : Unit -> Unit) (u : Unit) : f u = unit => {?{-caret-}} (f u)
+    """, """
+        \data Unit | unit
+
+        \func foo (f : Unit -> Unit) (u : Unit) : f u = unit => foo-lemma (f u)
+        
+        \func foo-lemma (u' : Unit) : u' = unit => {?}
+""")
 }

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -163,4 +163,12 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
          
          \func foo-lemma (n : Nat) (d : D n) : Nat => {?}
     """)
+
+    fun `test goal with arguments, inside binop`() = doTest("""
+        \func foo : Nat => {?{-caret-}} 1 Nat.+ 2
+    """, """
+        \func foo : Nat => foo-lemma 1 Nat.+ 2
+        
+        \func foo-lemma (n : Nat) : Nat => {?} 
+    """)
 }

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -131,4 +131,12 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
        
        \func foo-lemma : Nat => 1
     """)
+
+    fun `test goal with arguments`() = doTest("""
+        \func foo : Nat => {?{-caret-}} 1
+        """, """
+        \func foo : Nat => foo-lemma 1
+        
+        \func foo-lemma (n : Nat) : Nat => {?}
+        """)
 }

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -171,4 +171,12 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
         
         \func foo-lemma (n : Nat) : Nat => {?} 
     """)
+
+    fun `test goal with arguments, arguments with similar type`() = doTest("""
+       \func foo : Nat => {?{-caret-}} 1 1 
+    """, """
+       \func foo : Nat => foo-lemma 1 1
+       
+       \func foo-lemma (n n' : Nat) : Nat => {?} 
+    """)
 }

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -149,7 +149,7 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
 
         \func foo (f : Unit -> Unit) (u : Unit) : f u = unit => foo-lemma (f u)
         
-        \func foo-lemma (u' : Unit) : u' = unit => {?}
+        \func foo-lemma (u : Unit) : u = unit => {?}
     """)
 
     fun `test goal with arguments, dependency on argument`() = doTest("""

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -150,5 +150,17 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
         \func foo (f : Unit -> Unit) (u : Unit) : f u = unit => foo-lemma (f u)
         
         \func foo-lemma (u' : Unit) : u' = unit => {?}
-""")
+    """)
+
+    fun `test goal with arguments, dependency on argument`() = doTest("""
+        \data D (n : Nat) 
+        
+        \func foo (n : Nat) (d : D n) : Nat => {?{-caret-}} d
+    """, """
+         \data D (n : Nat) 
+        
+         \func foo (n : Nat) (d : D n) : Nat => (foo-lemma n) d
+         
+         \func foo-lemma (n : Nat) (d : D n) : Nat => {?}
+    """)
 }

--- a/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
+++ b/src/test/kotlin/org/arend/intention/GenerateFunctionFromGoalIntentionTest.kt
@@ -179,4 +179,24 @@ class GenerateFunctionFromGoalIntentionTest : QuickFixTestBase() {
        
        \func foo-lemma (n n' : Nat) : Nat => {?} 
     """)
+
+    fun `test in class`() = doTest("""
+      \class Foo {
+        | foo : Nat
+      }
+        
+      \class Bar \extends Foo {
+        | foo => {?{-caret-}}
+      }
+    """, """
+      \class Foo {
+        | foo : Nat
+      }
+        
+      \class Bar \extends Foo {
+        | foo => Bar-lemma
+      }
+       
+      \func Bar-lemma : Nat => {?}
+    """)
 }


### PR DESCRIPTION
Enhances "Generate function" intention, allowing to specify custom expressions as arguments to the generated function.
These expressions become substituted with binding in the function's codomain, so it will be convenient to pattern-match on some expression from the goal type.