### PR TITLE
Bugfix: show metas in external libraries when library name differs from registered library name (#311)

### DIFF
--- a/src/main/kotlin/org/arend/projectView/ArendProjectViewStructureProvider.kt
+++ b/src/main/kotlin/org/arend/projectView/ArendProjectViewStructureProvider.kt
@@ -14,9 +14,11 @@ import org.arend.ext.module.ModulePath
 import org.arend.module.AREND_LIB
 import org.arend.module.ArendLibraryKind
 import org.arend.module.ArendRawLibrary
+import org.arend.module.orderRoot.ArendConfigOrderRootType
 import org.arend.psi.ArendFile
 import org.arend.typechecking.TypeCheckingService
 import org.arend.util.FileUtils
+import org.arend.util.configFile
 
 class ArendProjectViewStructureProvider : TreeStructureProvider {
     override fun modify(parent: AbstractTreeNode<*>,
@@ -36,8 +38,9 @@ class ArendProjectViewStructureProvider : TreeStructureProvider {
     private fun findArendLibrary(parent: NamedLibraryElementNode): ArendRawLibrary? {
         val ideaLibrary = (parent.value?.orderEntry as? LibraryOrderEntry)?.library
         if (ideaLibrary is LibraryEx && ideaLibrary.kind is ArendLibraryKind) {
+            val configUrl = ideaLibrary.getUrls(ArendConfigOrderRootType).singleOrNull() ?: return null
             return parent.project?.service<TypeCheckingService>()?.libraryManager
-                    ?.getRegisteredLibrary(ideaLibrary.name)
+                    ?.getRegisteredLibrary { it is ArendRawLibrary && it.config.root?.configFile?.url == configUrl }
                     as? ArendRawLibrary
         }
         return null

--- a/src/test/kotlin/org/arend/project/ArendProjectViewTest.kt
+++ b/src/test/kotlin/org/arend/project/ArendProjectViewTest.kt
@@ -5,6 +5,7 @@ import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.ui.tree.TreeVisitor
 import com.intellij.util.ui.tree.TreeUtil
 import org.arend.ArendTestBase
+import org.arend.module.AREND_LIB
 
 class ArendProjectViewTest : ArendTestBase() {
     lateinit var treeStructure: TestProjectTreeStructure
@@ -31,6 +32,26 @@ class ArendProjectViewTest : ArendTestBase() {
                 | PsiDirectory: src
                 | -External Libraries
                 |  -Library: arend-lib
+                |   -ext
+                |    Meta.ard
+                |    Function.Meta.ard
+                |    Paths.Meta.ard
+                |   -PsiDirectory: src
+                |    Function.ard
+                |   arend.yaml
+                |  -arend-prelude
+                |   Prelude.ard
+            """.trimMargin())
+        }
+    }
+
+    fun `test arend-lib metas when library is renamed`() {
+        withStdLib(AREND_LIB + "_1") {
+            doTest("""
+                |-Project
+                | PsiDirectory: src
+                | -External Libraries
+                |  -Library: arend-lib_1
                 |   -ext
                 |    Meta.ard
                 |    Function.Meta.ard


### PR DESCRIPTION
![rename-lib-metas](https://user-images.githubusercontent.com/5653229/136237344-8a7497d1-42fb-41ec-8852-63e52f791b8e.gif)
