### PR TITLE
Allow ctrl+click to invoke find usages

### DIFF
--- a/src/main/kotlin/org/arend/highlight/ArendTargetElementEvaluator.kt
+++ b/src/main/kotlin/org/arend/highlight/ArendTargetElementEvaluator.kt
@@ -2,10 +2,24 @@ package org.arend.highlight
 
 import com.intellij.codeInsight.TargetElementEvaluatorEx2
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.parentOfType
+import com.intellij.psi.util.parents
+import com.intellij.refactoring.suggested.startOffset
 import org.arend.psi.ArendDefIdentifier
+import org.arend.psi.ArendDefinition
 import org.arend.psi.ArendRefIdentifier
+import org.arend.psi.ext.PsiReferable
 
 class ArendTargetElementEvaluator : TargetElementEvaluatorEx2() {
     override fun isAcceptableNamedParent(parent: PsiElement) =
             parent !is ArendRefIdentifier && parent !is ArendDefIdentifier
+
+    override fun getNamedElement(element: PsiElement): PsiElement? {
+        // protection against ArendDefIdentifier, as no references can resolve to it.
+        return element
+            .parents(true)
+            .filter { it is PsiReferable && it !is ArendDefIdentifier }
+            .firstOrNull()
+            ?.takeIf { (it as PsiReferable).nameIdentifier?.startOffset == element.startOffset  }
+    }
 }


### PR DESCRIPTION
Everyone knows that IDEs were created to hack with the mouse, not keyboard, so here it is.

![Peek 2021-10-18 18-39](https://user-images.githubusercontent.com/36202647/137764163-30945faf-2b4c-4715-acd4-efa80986185e.gif)
