### PR TITLE
Bugfix: names starting with semicolon must be considered valid (#298)

### DIFF
--- a/src/main/kotlin/org/arend/refactoring/ArendNamesValidator.kt
+++ b/src/main/kotlin/org/arend/refactoring/ArendNamesValidator.kt
@@ -11,8 +11,10 @@ object ArendNamesValidator : NamesValidator {
     override fun isKeyword(name: String, project: Project?): Boolean =
         getLexerType(name) in AREND_KEYWORDS
 
-    override fun isIdentifier(name: String, project: Project?): Boolean =
-        getLexerType(name) == ArendElementTypes.ID
+    override fun isIdentifier(name: String, project: Project?): Boolean {
+        val tokenType = getLexerType(name)
+        return tokenType == ArendElementTypes.ID || tokenType == ArendElementTypes.REPL_COMMAND
+    }
 
     private fun getLexerType(text : String): IElementType? {
         val lexer = ArendLexerAdapter()

--- a/src/test/kotlin/org/arend/refactoring/RenameTest.kt
+++ b/src/test/kotlin/org/arend/refactoring/RenameTest.kt
@@ -312,6 +312,12 @@ class RenameTest : ArendTestBase() {
          | con {bar} m => bar
     """)
 
+    fun `test name starts with a semicolon`() = doInlineTest(
+            ":b",
+            "\\func :a{-caret-} => {?}",
+            "\\func :b => {?}"
+    )
+
     private fun doTest(
             newName: String,
             @Language("Arend") before: String,


### PR DESCRIPTION
Arend lexer produces a special REPL_COMMAND token when the input contains only one token and it starts with a semicolon followed by an identifier. Such a sequence of symbols is a valid identifier too, so we allow REPL_COMMAND in ArendNamesValidator.